### PR TITLE
Auto-populate album name based on source directory selection if blank.

### DIFF
--- a/Picturebot/ViewModels/AddAlbumDialogViewModel.cs
+++ b/Picturebot/ViewModels/AddAlbumDialogViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
@@ -69,7 +70,23 @@ public partial class AddAlbumDialogViewModel : ViewModelBase {
             });
 
             if (folders.Any()) {
-                SourcePath = folders[0].Path.LocalPath;
+                var selectedPath = folders[0].Path.LocalPath;
+                SourcePath = selectedPath;
+
+                // Auto-populate Album Name if it is currently blank.
+                if (string.IsNullOrWhiteSpace(AlbumName)) {
+                    // Trim trailing slashes to ensure GetFileName safely extracts the leaf folder
+                    var cleanPath = selectedPath.TrimEnd(
+                        Path.DirectorySeparatorChar,
+                        Path.AltDirectorySeparatorChar
+                    );
+
+                    var suggestedName = Path.GetFileName(cleanPath);
+
+                    if (!string.IsNullOrWhiteSpace(suggestedName)) {
+                        AlbumName = suggestedName;
+                    }
+                }
             }
         } catch (Exception ex) {
             Log.Error(ex, "Error selecting source path");

--- a/Picturebot/Views/AddAlbumDialog.axaml
+++ b/Picturebot/Views/AddAlbumDialog.axaml
@@ -33,19 +33,6 @@
                 </ComboBox>
             </StackPanel>
 
-            <!-- Album Name -->
-            <StackPanel Spacing="10">
-                <TextBlock Text="ALBUM NAME"
-                           FontSize="11"
-                           FontWeight="Bold"
-                           Foreground="{DynamicResource SukiLowText}"
-                           LetterSpacing="1" />
-                <TextBox Text="{Binding AlbumName}"
-                         Watermark="e.g. Wedding 2024"
-                         Height="40"
-                         VerticalContentAlignment="Center" />
-            </StackPanel>
-
             <!-- Source Directory -->
             <StackPanel Spacing="10">
                 <TextBlock Text="SOURCE DIRECTORY (Images to import)"
@@ -68,6 +55,19 @@
                         <icons:MaterialIcon Kind="FolderOpen" Width="20" Height="20" />
                     </Button>
                 </Grid>
+            </StackPanel>
+
+            <!-- Album Name -->
+            <StackPanel Spacing="10">
+                <TextBlock Text="ALBUM NAME"
+                           FontSize="11"
+                           FontWeight="Bold"
+                           Foreground="{DynamicResource SukiLowText}"
+                           LetterSpacing="1" />
+                <TextBox Text="{Binding AlbumName}"
+                         Watermark="e.g. Wedding 2024"
+                         Height="40"
+                         VerticalContentAlignment="Center" />
             </StackPanel>
 
             <!-- Buttons -->


### PR DESCRIPTION
This pull request updates the album creation process to automatically populate the album name with the name of the selected source directory if no name is provided. This enhancement improves usability and reduces manual input errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Album name field now automatically populates from the selected folder's name when left blank.

* **Style**
  * Reordered the Album Name input section to appear after the Source Directory selection in the dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->