### PR TITLE
Return album object and add empty state for folders

### DIFF
--- a/Graph.Test/ImportPicturesCommandTests.cs
+++ b/Graph.Test/ImportPicturesCommandTests.cs
@@ -71,7 +71,7 @@ public class ImportPicturesCommandTests {
             .ReturnsAsync(mockImage);
 
         // Act
-        await _command.ExecuteAsync(parentId, albumName, libraryPath, sourcePath);
+        var resultAlbum = await _command.ExecuteAsync(parentId, albumName, libraryPath, sourcePath);
 
         // Assert
         var expectedFileName = capturedDate.ToString("yyyy-MM-dd_HH-mm-ss");
@@ -79,6 +79,12 @@ public class ImportPicturesCommandTests {
         var expectedThumbnailPath = Path.Combine(albumPath, "Thumbnails", expectedFileName + ".jpg");
 
         Assert.Multiple(() => {
+            Assert.That(resultAlbum, Is.Not.Null);
+            Assert.That(resultAlbum.Id, Is.EqualTo(album.Id));
+            Assert.That(resultAlbum.Children, Is.Not.Null);
+            Assert.That(resultAlbum.Children.Count, Is.EqualTo(1));
+            Assert.That(resultAlbum.Children.First().Name, Is.EqualTo(expectedFileName));
+
             Assert.That(_mockFileSystem.File.Exists(expectedJpgPath), Is.True, "JPG should be copied.");
             Assert.That(_mockFileSystem.File.Exists(expectedThumbnailPath), Is.True, "Thumbnail should be saved.");
             
@@ -131,12 +137,13 @@ public class ImportPicturesCommandTests {
             .ReturnsAsync(new Image<Rgba32>(1, 1));
 
         // Act
-        await _command.ExecuteAsync(parentId, albumName, libraryPath, sourcePath);
+        var resultAlbum = await _command.ExecuteAsync(parentId, albumName, libraryPath, sourcePath);
 
         // Assert
         var expectedFileName = baseFileName + "_1";
         var expectedJpgPath = Path.Combine(jpgsPath, expectedFileName + ".jpg");
 
+        Assert.That(resultAlbum.Children.First().Name, Is.EqualTo(expectedFileName));
         Assert.That(_mockFileSystem.File.Exists(expectedJpgPath), Is.True, "File should be renamed with suffix _1 due to collision.");
         _mockNodeService.Verify(s => s.CreateNodeAsync(It.Is<Picture>(p => p.Name == expectedFileName)), Times.Once);
     }

--- a/Graph/Infrastructure/Commands/ImportPicturesCommand.cs
+++ b/Graph/Infrastructure/Commands/ImportPicturesCommand.cs
@@ -34,7 +34,7 @@ public class ImportPicturesCommand {
         _fileGrouper = new FileGrouper(fileSystem, pictureAnalyzer);
     }
 
-    public async Task ExecuteAsync(int? parentId, string albumName, string libraryPath, string sourcePath, IProgress<ImportProgress>? progress = null) {
+    public async Task<Album> ExecuteAsync(int? parentId, string albumName, string libraryPath, string sourcePath, IProgress<ImportProgress>? progress = null) {
         // Task 1: Create the Album (Sub-folders are created by modified AlbumService)
         var album = await _albumService.CreateAsync(parentId, albumName, libraryPath);
         var albumPath = _fileSystem.Path.Combine(libraryPath, album.Uuid);
@@ -47,6 +47,8 @@ public class ImportPicturesCommand {
         var groups = await _fileGrouper.GroupFilesAsync(sourcePath);
         var totalCount = groups.Count;
         var processedCount = 0;
+
+        album.Children = new List<Node>();
 
         foreach (var group in groups) {
             processedCount++;
@@ -116,6 +118,9 @@ public class ImportPicturesCommand {
             };
             
             await _nodeService.CreateNodeAsync(pictureNode);
+            album.Children.Add(pictureNode);
         }
+
+        return album;
     }
 }

--- a/Graph/Infrastructure/Services/NodeService.cs
+++ b/Graph/Infrastructure/Services/NodeService.cs
@@ -21,6 +21,7 @@ public class NodeService(
 
         await strategy.ValidateAsync(node, parent);
         strategy.Prepare(node);
+        node.Parent = parent; // Ensure breadcrumbs work for the returned object
 
         await nodeRepository.CreateAsync(node);
     }

--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.0.5</Version>
+        <Version>1.0.6</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/AddAlbumDialogViewModel.cs
+++ b/Picturebot/ViewModels/AddAlbumDialogViewModel.cs
@@ -112,11 +112,17 @@ public partial class AddAlbumDialogViewModel : ViewModelBase {
             .TryShow();
 
         try {
-            await _importCommand.ExecuteAsync(SelectedParent?.Id, AlbumName, libraryPath, SourcePath, progress);
+            var album = await _importCommand.ExecuteAsync(SelectedParent?.Id, AlbumName, libraryPath, SourcePath, progress);
 
-            // We need to find the created album to return it, or modify ImportCommand to return it.
-            // For now, we'll refresh the tree via message in the parent VM.
-            _onResult(new Album { Name = AlbumName }); // Placeholder for result
+            // Fetch the parent to ensure breadcrumbs work correctly if we navigate immediately
+            if (album.ParentId.HasValue) {
+                // We don't have a direct way to fetch parent here easily without adding more dependencies,
+                // but ImportPicturesCommand could potentially be improved or we can rely on GalleryViewModel 
+                // to handle the breadcrumbs if it has enough info.
+                // Actually, the album object from AlbumService should have its ParentId set.
+            }
+
+            _onResult(album);
         } catch (Exception ex) {
             Console.WriteLine($"Import failed: {ex.Message}");
             _onResult(null);

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -15,7 +15,7 @@ using Serilog;
 
 namespace Picturebot.ViewModels;
 
-public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMessage> {
+public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMessage>, IRecipient<NodeCreatedMessage> {
     private readonly IPictureGroupingService _groupingService;
     private readonly INodeService _nodeService;
     private readonly IPathService _pathService;
@@ -59,6 +59,21 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
 
     public void Receive(NodeSelectedMessage message) {
         UpdateGallery(message.Value);
+    }
+
+    public void Receive(NodeCreatedMessage message) {
+        var newNode = message.Value;
+
+        if (newNode is not (Folder or Album)) {
+            return;
+        }
+
+        // If we are in the parent folder, add the new node to the items list
+        if (_currentNode?.Id == newNode.ParentId || (_currentNode == null && newNode.ParentId == null)) {
+            if (!Items.Any(i => i.Id == newNode.Id)) {
+                Items.Add(newNode);
+            }
+        }
     }
 
     [RelayCommand]

--- a/Picturebot/ViewModels/NavigationPaneViewModel.cs
+++ b/Picturebot/ViewModels/NavigationPaneViewModel.cs
@@ -83,6 +83,9 @@ public partial class NavigationPaneViewModel : ViewModelBase, IRecipient<NodeCre
                 // Broadcast creation to refresh the tree
                 WeakReferenceMessenger.Default.Send(new NodeCreatedMessage(result));
 
+                // Automatically navigate to the new album
+                WeakReferenceMessenger.Default.Send(new NodeSelectedMessage(result));
+
                 MainWindow.ToastManager.CreateToast()
                     .WithTitle("Success")
                     .WithContent($"Album '{result.Name}' import has completed.")

--- a/Picturebot/Views/GalleryView.axaml
+++ b/Picturebot/Views/GalleryView.axaml
@@ -109,6 +109,34 @@
 
         <Panel Grid.Row="2">
 
+            <!-- Empty State for Folders -->
+            <StackPanel VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Spacing="10">
+                <StackPanel.IsVisible>
+                    <MultiBinding Converter="{x:Static BoolConverters.And}">
+                        <Binding Path="!IsShowingAlbum" />
+                        <Binding Path="!Items.Count" />
+                    </MultiBinding>
+                </StackPanel.IsVisible>
+                <icons:MaterialIcon Kind="FolderOpen" Width="64" Height="64" Foreground="{DynamicResource SukiLowText}" />
+                <TextBlock Text="This folder is empty" FontSize="20" FontWeight="SemiBold" Foreground="{DynamicResource SukiLowText}" />
+            </StackPanel>
+
+            <!-- Empty State for Albums -->
+            <StackPanel VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        Spacing="10">
+                <StackPanel.IsVisible>
+                    <MultiBinding Converter="{x:Static BoolConverters.And}">
+                        <Binding Path="IsShowingAlbum" />
+                        <Binding Path="!PicturesList.Count" />
+                    </MultiBinding>
+                </StackPanel.IsVisible>
+                <icons:MaterialIcon Kind="ImageAlbum" Width="64" Height="64" Foreground="{DynamicResource SukiLowText}" />
+                <TextBlock Text="This album is empty" FontSize="20" FontWeight="SemiBold" Foreground="{DynamicResource SukiLowText}" />
+            </StackPanel>
+
             <ScrollViewer IsVisible="{Binding !IsShowingAlbum}" Padding="20,10,20,20">
                 <ItemsControl ItemsSource="{Binding Items}">
                     <ItemsControl.ItemsPanel>


### PR DESCRIPTION
### Description

This pull request includes the following updates:
- Updated `ImportPicturesCommand` to return the album object and ensure the user navigates to newly created albums.
- Added an empty state UI for folders in the `GalleryView`.
- Enhanced `GalleryViewModel` to handle `NodeCreatedMessage`.
- Bumped the project version to `1.0.6`.

### Checklist

- [ ] Tests added/updated where applicable.
- [ ] Documentation updated where applicable.
- [ ] Code changes reviewed and approved.
- [ ] All checks have passed.
- [ ] Version number updated in `CHANGELOG.md` where applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added empty state messages for empty folders and albums.
  * Auto-navigation to newly created albums after import.
  * Real-time gallery updates when albums are created.

* **Bug Fixes**
  * Improved album data handling during imports.
  * Fixed parent node reference consistency.

* **Chores**
  * Version updated to 1.0.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->