### PR TITLE
test: add unit tests for FolderService and fix folder filtering logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ riderModule.iml
 
 .idea/*
 Picturebot.sln.DotSettings.user
+
+*.ps1

--- a/Graph.Test/FolderServiceTests.cs
+++ b/Graph.Test/FolderServiceTests.cs
@@ -1,0 +1,39 @@
+using Database.Domain.Entities;
+using Domain.Enums;
+using Graph.Domain.Interfaces;
+using Graph.Infrastructure.Services;
+using Moq;
+
+namespace Graph.Test;
+
+[TestFixture]
+public class FolderServiceTests {
+    private Mock<INodeService> _nodeServiceMock;
+    private FolderService _folderService;
+
+    [SetUp]
+    public void Setup() {
+        _nodeServiceMock = new Mock<INodeService>();
+        _folderService = new FolderService(_nodeServiceMock.Object);
+    }
+
+    [Test]
+    public async Task FindAllAsync_ShouldOnlyReturnFoldersWithFolderType() {
+        // Arrange
+        var nodes = new List<Node> {
+            new Folder { Id = 1, Name = "Real Folder", Type = NodeType.Folder },
+            new Album { Id = 2, Name = "Album", Type = NodeType.Album },
+            new Folder { Id = 3, Name = "Misclassed Album", Type = NodeType.Album } // Misclassed but is a Folder object
+        };
+
+        _nodeServiceMock.Setup(s => s.GetAllNodesAsync()).ReturnsAsync(nodes);
+
+        // Act
+        var result = await _folderService.FindAllAsync();
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].Name, Is.EqualTo("Real Folder"));
+        Assert.That(result[0].Type, Is.EqualTo(NodeType.Folder));
+    }
+}

--- a/Graph/Infrastructure/Services/FolderService.cs
+++ b/Graph/Infrastructure/Services/FolderService.cs
@@ -19,6 +19,8 @@ public class FolderService(INodeService nodeService) : IFolderService {
     public async Task<List<Folder>> FindAllAsync() {
         var allNodes = await nodeService.GetAllNodesAsync();
 
-        return allNodes.OfType<Folder>().ToList();
+        return allNodes.OfType<Folder>()
+            .Where(n => n.Type == NodeType.Folder)
+            .ToList();
     }
 }

--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.1.1</Version>
+        <Version>1.1.2</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Add `FolderServiceTests` to validate folder filtering by NodeType. Update `FolderService.FindAllAsync` to ensure only folders with `NodeType.Folder` are returned. Bumped version to 1.1.2. Updated `.gitignore` to exclude PowerShell scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed folder enumeration to properly filter items by folder type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->