### PR TITLE
feat: separate folders and albums in GalleryView, update view model logic

### DIFF
--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.1.2</Version>
+        <Version>1.1.3</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -43,6 +43,12 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
     private ObservableCollection<Node> _items = new();
 
     [ObservableProperty]
+    private ObservableCollection<Node> _folderItems = new();
+
+    [ObservableProperty]
+    private ObservableCollection<Node> _albumItems = new();
+
+    [ObservableProperty]
     private ObservableCollection<PictureItemViewModel> _picturesList = new();
 
     [ObservableProperty]
@@ -72,6 +78,11 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
         if (_currentNode?.Id == newNode.ParentId || (_currentNode == null && newNode.ParentId == null)) {
             if (!Items.Any(i => i.Id == newNode.Id)) {
                 Items.Add(newNode);
+                if (newNode is Folder) {
+                    FolderItems.Add(newNode);
+                } else if (newNode is Album) {
+                    AlbumItems.Add(newNode);
+                }
             }
         }
     }
@@ -235,8 +246,11 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
 
     private void UpdateGalleryItems(Node? currentNode, List<Node>? children) {
         _currentNode = currentNode;
-        // Clear both collections to prevent ghosting
+        // Clear collections to prevent ghosting
         Items.Clear();
+        FolderItems.Clear();
+        AlbumItems.Clear();
+
         foreach (var picVm in PicturesList) {
             picVm.Dispose();
         }
@@ -263,8 +277,14 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
 
                 _ = RefreshGalleryGrouping();
             } else {
-                foreach (var child in children.Where(n => n is Folder || n is Album)) {
+                var list = children.Where(n => n is Folder || n is Album).ToList();
+                foreach (var child in list) {
                     Items.Add(child);
+                    if (child is Folder) {
+                        FolderItems.Add(child);
+                    } else if (child is Album) {
+                        AlbumItems.Add(child);
+                    }
                 }
             }
         }

--- a/Picturebot/Views/GalleryView.axaml
+++ b/Picturebot/Views/GalleryView.axaml
@@ -138,44 +138,101 @@
             </StackPanel>
 
             <ScrollViewer IsVisible="{Binding !IsShowingAlbum}" Padding="20,10,20,20">
-                <ItemsControl ItemsSource="{Binding Items}">
-                    <ItemsControl.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <WrapPanel Orientation="Horizontal" />
-                        </ItemsPanelTemplate>
-                    </ItemsControl.ItemsPanel>
+                <StackPanel Spacing="30">
+                    <!-- Folders Section -->
+                    <StackPanel Spacing="10" IsVisible="{Binding FolderItems.Count}">
+                        <StackPanel Orientation="Horizontal" Spacing="10" Margin="5,0">
+                            <icons:MaterialIcon Kind="FolderOutline" Width="20" Height="20" Foreground="{DynamicResource SukiLowText}" />
+                            <TextBlock Text="Folders" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource SukiText}" />
+                        </StackPanel>
+                        
+                        <ItemsControl ItemsSource="{Binding FolderItems}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel Orientation="Horizontal" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
 
-                    <ItemsControl.ItemTemplate>
-                        <DataTemplate x:DataType="entities:Node">
-                            <Button Classes="Basic"
-                                    Command="{Binding $parent[ItemsControl].((vm:GalleryViewModel)DataContext).NavigateToChildCommand}"
-                                    CommandParameter="{Binding}"
-                                    Margin="10"
-                                    Padding="0"
-                                    CornerRadius="12"
-                                    Cursor="Hand">
-                                <suki:GlassCard Width="160" Height="140">
-                                    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="10">
-                                        <Panel Width="48" Height="48">
-                                            <icons:MaterialIcon Kind="Folder"
-                                                                IsVisible="{Binding Type, Converter={StaticResource NodeTypeToBooleanConverter}, ConverterParameter=Folder}"
-                                                                Width="48" Height="48" Foreground="#FFD700" />
-                                            <icons:MaterialIcon Kind="ImageAlbum"
-                                                                IsVisible="{Binding Type, Converter={StaticResource NodeTypeToBooleanConverter}, ConverterParameter=Album}"
-                                                                Width="48" Height="48" Foreground="#87CEEB" />
-                                        </Panel>
-                                        <TextBlock Text="{Binding Name}"
-                                                   HorizontalAlignment="Center"
-                                                   TextWrapping="Wrap"
-                                                   TextAlignment="Center"
-                                                   FontWeight="SemiBold"
-                                                   Foreground="{DynamicResource SukiText}" />
-                                    </StackPanel>
-                                </suki:GlassCard>
-                            </Button>
-                        </DataTemplate>
-                    </ItemsControl.ItemTemplate>
-                </ItemsControl>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="entities:Node">
+                                    <Button Classes="Basic"
+                                            Command="{Binding $parent[ItemsControl].((vm:GalleryViewModel)DataContext).NavigateToChildCommand}"
+                                            CommandParameter="{Binding}"
+                                            Margin="10"
+                                            Padding="0"
+                                            CornerRadius="12"
+                                            Cursor="Hand">
+                                        <suki:GlassCard Width="160" Height="140">
+                                            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="10">
+                                                <Panel Width="48" Height="48">
+                                                    <icons:MaterialIcon Kind="Folder"
+                                                                        IsVisible="{Binding Type, Converter={StaticResource NodeTypeToBooleanConverter}, ConverterParameter=Folder}"
+                                                                        Width="48" Height="48" Foreground="#FFD700" />
+                                                    <icons:MaterialIcon Kind="ImageAlbum"
+                                                                        IsVisible="{Binding Type, Converter={StaticResource NodeTypeToBooleanConverter}, ConverterParameter=Album}"
+                                                                        Width="48" Height="48" Foreground="#87CEEB" />
+                                                </Panel>
+                                                <TextBlock Text="{Binding Name}"
+                                                           HorizontalAlignment="Center"
+                                                           TextWrapping="Wrap"
+                                                           TextAlignment="Center"
+                                                           FontWeight="SemiBold"
+                                                           Foreground="{DynamicResource SukiText}" />
+                                            </StackPanel>
+                                        </suki:GlassCard>
+                                    </Button>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+
+                    <!-- Albums Section -->
+                    <StackPanel Spacing="10" IsVisible="{Binding AlbumItems.Count}">
+                        <StackPanel Orientation="Horizontal" Spacing="10" Margin="5,0">
+                            <icons:MaterialIcon Kind="ImageAlbum" Width="20" Height="20" Foreground="{DynamicResource SukiLowText}" />
+                            <TextBlock Text="Albums" FontSize="18" FontWeight="Bold" Foreground="{DynamicResource SukiText}" />
+                        </StackPanel>
+
+                        <ItemsControl ItemsSource="{Binding AlbumItems}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <WrapPanel Orientation="Horizontal" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="entities:Node">
+                                    <Button Classes="Basic"
+                                            Command="{Binding $parent[ItemsControl].((vm:GalleryViewModel)DataContext).NavigateToChildCommand}"
+                                            CommandParameter="{Binding}"
+                                            Margin="10"
+                                            Padding="0"
+                                            CornerRadius="12"
+                                            Cursor="Hand">
+                                        <suki:GlassCard Width="160" Height="140">
+                                            <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="10">
+                                                <Panel Width="48" Height="48">
+                                                    <icons:MaterialIcon Kind="Folder"
+                                                                        IsVisible="{Binding Type, Converter={StaticResource NodeTypeToBooleanConverter}, ConverterParameter=Folder}"
+                                                                        Width="48" Height="48" Foreground="#FFD700" />
+                                                    <icons:MaterialIcon Kind="ImageAlbum"
+                                                                        IsVisible="{Binding Type, Converter={StaticResource NodeTypeToBooleanConverter}, ConverterParameter=Album}"
+                                                                        Width="48" Height="48" Foreground="#87CEEB" />
+                                                </Panel>
+                                                <TextBlock Text="{Binding Name}"
+                                                           HorizontalAlignment="Center"
+                                                           TextWrapping="Wrap"
+                                                           TextAlignment="Center"
+                                                           FontWeight="SemiBold"
+                                                           Foreground="{DynamicResource SukiText}" />
+                                            </StackPanel>
+                                        </suki:GlassCard>
+                                    </Button>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </StackPanel>
             </ScrollViewer>
 
             <ScrollViewer IsVisible="{Binding IsShowingAlbum}" Padding="20,10,20,20">


### PR DESCRIPTION
Refactor `GalleryView` to display folders and albums in distinct sections. Update `GalleryViewModel` to manage `FolderItems` and `AlbumItems` collections separately. Bump version to 1.1.3.
