### PR TITLE
fix: ensure album.Children is initialized and prevent duplicate additions; bump version to 1.2.6

### DIFF
--- a/Graph/Infrastructure/Commands/ImportPicturesCommand.cs
+++ b/Graph/Infrastructure/Commands/ImportPicturesCommand.cs
@@ -51,8 +51,6 @@ public class ImportPicturesCommand : IImportPicturesCommand {
         var totalCount = groups.Count;
         var processedCount = 0;
 
-        album.Children = new List<Node>();
-
         foreach (var group in groups) {
             processedCount++;
             var currentFile = group.BaseName;
@@ -139,7 +137,14 @@ public class ImportPicturesCommand : IImportPicturesCommand {
             };
 
             await _nodeService.CreateNodeAsync(pictureNode);
-            album.Children.Add(pictureNode);
+            
+            // The service already set pictureNode.Parent = album, which might trigger EF fix-up
+            // and add it to album.Children if they share the same context. 
+            // We check to avoid doubling.
+            album.Children ??= new List<Node>();
+            if (!album.Children.Contains(pictureNode)) {
+                album.Children.Add(pictureNode);
+            }
         }
 
         return album;

--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.2.5</Version>
+        <Version>1.2.6</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where duplicate picture entries could be created during the picture import process, improving data integrity when adding pictures to albums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->