### PR TITLE
fix: update GalleryViewModel date and picture ordering logic; bump version to 1.2.8

### DIFF
--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.2.7</Version>
+        <Version>1.2.8</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -155,7 +155,7 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
 
     private void ApplyDateGrouping() {
         var groups = PicturesList.GroupBy(p => p.Picture.CapturedAt.Date)
-            .OrderByDescending(g => g.Key);
+            .OrderBy(g => g.Key);
 
         foreach (var group in groups) {
             var dateStr = group.Key.ToString("yyyy-MM-dd");
@@ -331,7 +331,7 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
         if (children != null) {
             if (IsShowingAlbum) {
                 var pics = children.OfType<Picture>()
-                    .OrderByDescending(p => p.CapturedAt)
+                    .OrderBy(p => p.CapturedAt)
                     .ToList();
 
                 _pathService.PopulatePaths(pics);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.2.8

* **Bug Fixes**
  * Updated gallery and album sorting to display items in chronological order (oldest-first) instead of reverse chronological order (newest-first)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->