### PR TITLE
Add burst grouping thresholds and simplify grouping logic

### DIFF
--- a/Database/Domain/Entities/Picture.cs
+++ b/Database/Domain/Entities/Picture.cs
@@ -21,6 +21,16 @@ public class Picture : Node {
     public DateTime CapturedAt { get; set; }
 
     /// <summary>
+    ///     The width of the picture in pixels.
+    /// </summary>
+    public int Width { get; set; }
+
+    /// <summary>
+    ///     The height of the picture in pixels.
+    /// </summary>
+    public int Height { get; set; }
+
+    /// <summary>
     ///     The perceptual hash of the picture.
     /// </summary>
     public ulong Hash { get; set; }

--- a/Database/Domain/Entities/Settings.cs
+++ b/Database/Domain/Entities/Settings.cs
@@ -31,6 +31,21 @@ public class Settings {
     public int GroupingThreshold { get; set; } = 5;
 
     /// <summary>
+    ///     Maximum time gap in seconds to consider pictures as part of a burst without checking visual similarity.
+    /// </summary>
+    public int BurstTimeThresholdSeconds { get; set; } = 3;
+
+    /// <summary>
+    ///     Maximum time gap in seconds to consider pictures as part of a burst if they are visually similar.
+    /// </summary>
+    public int BurstFallbackTimeThresholdSeconds { get; set; } = 10;
+
+    /// <summary>
+    ///     Perceptual hash threshold for the fallback burst grouping.
+    /// </summary>
+    public int BurstHashSimilarityThreshold { get; set; } = 8;
+
+    /// <summary>
     ///     Indicates whether the application should launch in a maximized window state.
     /// </summary>
     public bool LaunchMaximized { get; set; }

--- a/Database/Domain/Entities/Settings.cs
+++ b/Database/Domain/Entities/Settings.cs
@@ -41,11 +41,6 @@ public class Settings {
     public int BurstFallbackTimeThresholdSeconds { get; set; } = 10;
 
     /// <summary>
-    ///     Perceptual hash threshold for the fallback burst grouping.
-    /// </summary>
-    public int BurstHashSimilarityThreshold { get; set; } = 8;
-
-    /// <summary>
     ///     Indicates whether the application should launch in a maximized window state.
     /// </summary>
     public bool LaunchMaximized { get; set; }

--- a/Database/Infrastructure/Data/ApplicationDBContext.cs
+++ b/Database/Infrastructure/Data/ApplicationDBContext.cs
@@ -70,7 +70,6 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> dbConte
                 GroupingThreshold = 8,
                 BurstTimeThresholdSeconds = 3,
                 BurstFallbackTimeThresholdSeconds = 10,
-                BurstHashSimilarityThreshold = 8,
                 LaunchMaximized = false
             }
         );

--- a/Database/Infrastructure/Data/ApplicationDBContext.cs
+++ b/Database/Infrastructure/Data/ApplicationDBContext.cs
@@ -67,7 +67,10 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> dbConte
                 Id = 1,
                 ThemeMode = ThemeMode.System,
                 LibraryPath = "",
-                GroupingThreshold = 5,
+                GroupingThreshold = 8,
+                BurstTimeThresholdSeconds = 3,
+                BurstFallbackTimeThresholdSeconds = 10,
+                BurstHashSimilarityThreshold = 8,
                 LaunchMaximized = false
             }
         );

--- a/Database/Infrastructure/Repositories/SettingsRepository.cs
+++ b/Database/Infrastructure/Repositories/SettingsRepository.cs
@@ -3,6 +3,7 @@ using Database.Domain.Interfaces;
 using Database.Infrastructure.Data;
 using Database.Infrastructure.Mappers;
 using Domain.Models;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace Database.Infrastructure.Repositories;
@@ -14,17 +15,24 @@ public class SettingsRepository(ApplicationDbContext context) : ISettingsReposit
     private readonly SettingsMapper _mapper = new();
 
     public async Task<SettingsModel> LoadAsync() {
-        var entity = await context.Settings.FirstOrDefaultAsync(s => s.Id == 1);
+        try {
+            var entity = await context.Settings.FirstOrDefaultAsync(s => s.Id == 1);
 
-        if (entity != null) {
+            if (entity != null) {
+                return _mapper.EntityToModel(entity);
+            }
+
+            entity = new Settings { Id = 1 };
+            context.Settings.Add(entity);
+            await context.SaveChangesAsync();
+
             return _mapper.EntityToModel(entity);
+        } catch (Exception ex) when (ex.InnerException is SqliteException or SqliteException) {
+            // Use Console as fallback if logger is not available in this layer
+            Console.WriteLine($"Database schema mismatch detected while loading settings. Using defaults. Error: {ex.Message}");
+            // Return defaults from Model to allow app to start
+            return new SettingsModel();
         }
-
-        entity = new Settings { Id = 1 };
-        context.Settings.Add(entity);
-        await context.SaveChangesAsync();
-
-        return _mapper.EntityToModel(entity);
     }
 
     public async Task UpdateAsync(SettingsModel updatedSettings) {

--- a/Database/Migrations/20260428165448_AddBurstSettings.Designer.cs
+++ b/Database/Migrations/20260428165448_AddBurstSettings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Database.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260428165448_AddBurstSettings")]
+    partial class AddBurstSettings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.12");
@@ -70,6 +73,9 @@ namespace Database.Migrations
                     b.Property<int>("BurstFallbackTimeThresholdSeconds")
                         .HasColumnType("INTEGER");
 
+                    b.Property<int>("BurstHashSimilarityThreshold")
+                        .HasColumnType("INTEGER");
+
                     b.Property<int>("BurstTimeThresholdSeconds")
                         .HasColumnType("INTEGER");
 
@@ -95,6 +101,7 @@ namespace Database.Migrations
                         {
                             Id = 1,
                             BurstFallbackTimeThresholdSeconds = 10,
+                            BurstHashSimilarityThreshold = 8,
                             BurstTimeThresholdSeconds = 3,
                             GroupingThreshold = 8,
                             LaunchMaximized = false,

--- a/Database/Migrations/20260428165448_AddBurstSettings.cs
+++ b/Database/Migrations/20260428165448_AddBurstSettings.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBurstSettings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BurstFallbackTimeThresholdSeconds",
+                table: "settings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "BurstHashSimilarityThreshold",
+                table: "settings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "BurstTimeThresholdSeconds",
+                table: "settings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Height",
+                table: "pictures",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Width",
+                table: "pictures",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.UpdateData(
+                table: "settings",
+                keyColumn: "Id",
+                keyValue: 1,
+                columns: new[] { "BurstFallbackTimeThresholdSeconds", "BurstHashSimilarityThreshold", "BurstTimeThresholdSeconds", "GroupingThreshold" },
+                values: new object[] { 10, 8, 3, 8 });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BurstFallbackTimeThresholdSeconds",
+                table: "settings");
+
+            migrationBuilder.DropColumn(
+                name: "BurstHashSimilarityThreshold",
+                table: "settings");
+
+            migrationBuilder.DropColumn(
+                name: "BurstTimeThresholdSeconds",
+                table: "settings");
+
+            migrationBuilder.DropColumn(
+                name: "Height",
+                table: "pictures");
+
+            migrationBuilder.DropColumn(
+                name: "Width",
+                table: "pictures");
+
+            migrationBuilder.UpdateData(
+                table: "settings",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "GroupingThreshold",
+                value: 5);
+        }
+    }
+}

--- a/Database/Migrations/20260429071947_RemoveBurstHashThreshold.Designer.cs
+++ b/Database/Migrations/20260429071947_RemoveBurstHashThreshold.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Database.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429071947_RemoveBurstHashThreshold")]
+    partial class RemoveBurstHashThreshold
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.12");

--- a/Database/Migrations/20260429071947_RemoveBurstHashThreshold.cs
+++ b/Database/Migrations/20260429071947_RemoveBurstHashThreshold.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveBurstHashThreshold : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "BurstHashSimilarityThreshold",
+                table: "settings");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "BurstHashSimilarityThreshold",
+                table: "settings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.UpdateData(
+                table: "settings",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "BurstHashSimilarityThreshold",
+                value: 8);
+        }
+    }
+}

--- a/Database/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Database/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -67,6 +67,15 @@ namespace Database.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("INTEGER");
 
+                    b.Property<int>("BurstFallbackTimeThresholdSeconds")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("BurstHashSimilarityThreshold")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("BurstTimeThresholdSeconds")
+                        .HasColumnType("INTEGER");
+
                     b.Property<int>("GroupingThreshold")
                         .HasColumnType("INTEGER");
 
@@ -88,7 +97,10 @@ namespace Database.Migrations
                         new
                         {
                             Id = 1,
-                            GroupingThreshold = 5,
+                            BurstFallbackTimeThresholdSeconds = 10,
+                            BurstHashSimilarityThreshold = 8,
+                            BurstTimeThresholdSeconds = 3,
+                            GroupingThreshold = 8,
                             LaunchMaximized = false,
                             LibraryPath = "",
                             ThemeMode = 0
@@ -127,7 +139,13 @@ namespace Database.Migrations
                     b.Property<long>("Hash")
                         .HasColumnType("INTEGER");
 
+                    b.Property<int>("Height")
+                        .HasColumnType("INTEGER");
+
                     b.Property<int>("Sharpness")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<int>("Width")
                         .HasColumnType("INTEGER");
 
                     b.ToTable("pictures", (string)null);

--- a/Domain/Models/SettingsModel.cs
+++ b/Domain/Models/SettingsModel.cs
@@ -22,10 +22,5 @@ public class SettingsModel {
     /// </summary>
     public int BurstFallbackTimeThresholdSeconds { get; set; } = 10;
 
-    /// <summary>
-    ///     Perceptual hash threshold for the fallback burst grouping.
-    /// </summary>
-    public int BurstHashSimilarityThreshold { get; set; } = 8;
-
     public bool LaunchMaximized { get; set; } = false;
 }

--- a/Domain/Models/SettingsModel.cs
+++ b/Domain/Models/SettingsModel.cs
@@ -1,4 +1,4 @@
-﻿using Domain.Enums;
+using Domain.Enums;
 
 namespace Domain.Models;
 
@@ -7,7 +7,25 @@ public class SettingsModel {
 
     public string? LibraryPath { get; set; }
 
-    public int GroupingThreshold { get; set; } = 10;
+    /// <summary>
+    ///     Perceptual hash threshold for grouping similar pictures (Lower is stricter, 8-10 is typical).
+    /// </summary>
+    public int GroupingThreshold { get; set; } = 8;
+
+    /// <summary>
+    ///     Maximum time gap in seconds to consider pictures as part of a burst without checking visual similarity.
+    /// </summary>
+    public int BurstTimeThresholdSeconds { get; set; } = 3;
+
+    /// <summary>
+    ///     Maximum time gap in seconds to consider pictures as part of a burst if they are visually similar.
+    /// </summary>
+    public int BurstFallbackTimeThresholdSeconds { get; set; } = 10;
+
+    /// <summary>
+    ///     Perceptual hash threshold for the fallback burst grouping.
+    /// </summary>
+    public int BurstHashSimilarityThreshold { get; set; } = 8;
 
     public bool LaunchMaximized { get; set; } = false;
 }

--- a/Graph.Test/FileGrouperTests.cs
+++ b/Graph.Test/FileGrouperTests.cs
@@ -1,89 +1,171 @@
 using System.IO.Abstractions.TestingHelpers;
 using Graph.Infrastructure.Utilities;
-using Moq;
-using PictureWorker.Domain.Interfaces;
-using ErrorOr;
+// Assumes CachedPictureData and FileGroup are here
 
 namespace Graph.Test;
 
 [TestFixture]
 public class FileGrouperTests {
     private MockFileSystem _mockFileSystem;
-    private Mock<IPictureAnalyzer> _mockPictureAnalyzer;
     private FileGrouper _fileGrouper;
 
     [SetUp]
     public void Setup() {
+        // MockFileSystem automatically handles cross-platform Path operations 
+        // without needing to touch the physical disk.
         _mockFileSystem = new MockFileSystem();
-        _mockPictureAnalyzer = new Mock<IPictureAnalyzer>();
-        _fileGrouper = new FileGrouper(_mockFileSystem, _mockPictureAnalyzer.Object);
+        _fileGrouper = new FileGrouper(_mockFileSystem);
+    }
+
+    // Helper method to keep test arrangement clean
+    private static CachedPictureData CreateCachedData(string path, DateTime time, ulong pHash) {
+        return new CachedPictureData {
+            FilePath = path,
+            PrimaryDate = time,
+            PHash = pHash
+        };
     }
 
     [Test]
-    public async Task GroupFilesAsync_ShouldGroupFilesByBaseName() {
+    public void GroupFiles_ShouldGroupByTimeAndHash_WhenWithinThreshold() {
         // Arrange
-        var sourcePath = @"C:\Source";
-        _mockFileSystem.AddDirectory(sourcePath);
-        _mockFileSystem.AddFile(Path.Combine(sourcePath, "photo1.jpg"), new MockFileData(""));
-        _mockFileSystem.AddFile(Path.Combine(sourcePath, "photo1.raw"), new MockFileData(""));
-        _mockFileSystem.AddFile(Path.Combine(sourcePath, "photo2.jpg"), new MockFileData(""));
+        var baseTime = new DateTime(2025, 1, 1, 12, 0, 0);
 
-        _mockPictureAnalyzer.Setup(a => a.ExtractTimestamp(It.IsAny<string>()))
-            .ReturnsAsync(Error.Failure("No metadata"));
+        // Hashes differ by exactly 1 bit (Hamming distance = 1), well within threshold
+        var files = new List<CachedPictureData> {
+            CreateCachedData(@"C:\Source\Seq_100.jpg", baseTime, 0b0000),
+            CreateCachedData(@"C:\Source\Seq_101.jpg", baseTime.AddSeconds(1), 0b0001),
+            CreateCachedData(@"C:\Source\Seq_102.jpg", baseTime.AddSeconds(2), 0b0011)
+        };
 
         // Act
-        var result = await _fileGrouper.GroupFilesAsync(sourcePath);
-
-        // Assert
-        Assert.That(result, Has.Count.EqualTo(2));
-        var group1 = result.First(g => g.BaseName == "photo1");
-        Assert.That(group1.FilePaths, Has.Count.EqualTo(2));
-        var group2 = result.First(g => g.BaseName == "photo2");
-        Assert.That(group2.FilePaths, Has.Count.EqualTo(1));
-    }
-
-    [Test]
-    public async Task GroupFilesAsync_ShouldPrioritizeMetadataTimestamp() {
-        // Arrange
-        var sourcePath = @"C:\Source";
-        var metadataDate = new DateTime(2025, 1, 1, 12, 0, 0);
-        _mockFileSystem.AddDirectory(sourcePath);
-        var jpgPath = Path.Combine(sourcePath, "photo1.jpg");
-        var rawPath = Path.Combine(sourcePath, "photo1.raw");
-        _mockFileSystem.AddFile(jpgPath, new MockFileData(""));
-        _mockFileSystem.AddFile(rawPath, new MockFileData(""));
-
-        // Mock jpg having no metadata, but raw having it
-        _mockPictureAnalyzer.Setup(a => a.ExtractTimestamp(jpgPath))
-            .ReturnsAsync(Error.Failure("No metadata"));
-        _mockPictureAnalyzer.Setup(a => a.ExtractTimestamp(rawPath))
-            .ReturnsAsync(metadataDate);
-
-        // Act
-        var result = await _fileGrouper.GroupFilesAsync(sourcePath);
-
-        // Assert
-        var group = result.First(g => g.BaseName == "photo1");
-        Assert.That(group.PrimaryDate, Is.EqualTo(metadataDate));
-    }
-
-    [Test]
-    public async Task GroupFilesAsync_ShouldIgnoreGhostFiles() {
-        // Arrange
-        var sourcePath = @"C:\Source";
-        _mockFileSystem.AddDirectory(sourcePath);
-        _mockFileSystem.AddFile(Path.Combine(sourcePath, "photo1.jpg"), new MockFileData(""));
-        _mockFileSystem.AddFile(Path.Combine(sourcePath, "._photo1.jpg"), new MockFileData("mac ghost"));
-        _mockFileSystem.AddFile(Path.Combine(sourcePath, ".DS_Store"), new MockFileData("ds store"));
-
-        _mockPictureAnalyzer.Setup(a => a.ExtractTimestamp(It.IsAny<string>()))
-            .ReturnsAsync(Error.Failure("No metadata"));
-
-        // Act
-        var result = await _fileGrouper.GroupFilesAsync(sourcePath);
+        var result = _fileGrouper.GroupFiles(files);
 
         // Assert
         Assert.That(result, Has.Count.EqualTo(1));
-        Assert.That(result[0].BaseName, Is.EqualTo("photo1"));
+        Assert.That(result[0].FilePaths, Has.Count.EqualTo(3));
+        Assert.That(result[0].BaseName, Does.StartWith("Burst_"));
+    }
+
+    [Test]
+    public void GroupFiles_ShouldGroupExactNames_CaseInsensitive() {
+        // Arrange
+        var baseTime = new DateTime(2025, 1, 1, 12, 0, 0);
+        var files = new List<CachedPictureData> {
+            CreateCachedData(@"C:\Source\IMG_001.JPG", baseTime, 0),
+            CreateCachedData(@"C:\Source\img_001.cr2", baseTime, 0)
+        };
+
+        // Act
+        var result = _fileGrouper.GroupFiles(files);
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].BaseName, Is.EqualTo("IMG_001").IgnoreCase);
+        Assert.That(result[0].FilePaths, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void GroupFiles_ShouldGroupExplicitBurstPatterns() {
+        // Arrange
+        var baseTime = new DateTime(2025, 1, 1, 12, 0, 0);
+        var files = new List<CachedPictureData> {
+            CreateCachedData(@"C:\Source\Photo_BURST1.jpg", baseTime, 0),
+            CreateCachedData(@"C:\Source\Photo_BURST2.jpg", baseTime, 0),
+            CreateCachedData(@"C:\Source\Event-1.jpg", baseTime, 0),
+            CreateCachedData(@"C:\Source\Event-2.jpg", baseTime, 0)
+        };
+
+        // Act
+        var result = _fileGrouper.GroupFiles(files);
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(2), "Should create two distinct pattern groups");
+
+        var burstGroup = result.First(g => g.BaseName == "Photo");
+        Assert.That(burstGroup.FilePaths, Has.Count.EqualTo(2));
+
+        var eventGroup = result.First(g => g.BaseName == "Event");
+        Assert.That(eventGroup.FilePaths, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void GroupFiles_ShouldHandleEmptyList() {
+        // Arrange
+        var files = new List<CachedPictureData>();
+
+        // Act
+        var result = _fileGrouper.GroupFiles(files);
+
+        // Assert
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void GroupFiles_ShouldProcessWaterfallCorrectly_PatternThenTime() {
+        // Arrange
+        var baseTime = new DateTime(2025, 1, 1, 12, 0, 0);
+
+        var files = new List<CachedPictureData> {
+            // Pair 1: Should be caught by Pass 1 (Exact Match)
+            CreateCachedData(@"C:\Source\Pair1.jpg", baseTime, 100),
+            CreateCachedData(@"C:\Source\Pair1.raw", baseTime, 100),
+
+            // Burst: Should be caught by Pass 2 (Time & Hash)
+            CreateCachedData(@"C:\Source\Random_01.jpg", baseTime.AddMinutes(5), 0b1010),
+            CreateCachedData(@"C:\Source\Random_02.jpg", baseTime.AddMinutes(5).AddSeconds(1), 0b1010)
+        };
+
+        // Act
+        var result = _fileGrouper.GroupFiles(files);
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(2));
+
+        var patternGroup = result.FirstOrDefault(g => g.BaseName == "Pair1");
+        Assert.That(patternGroup, Is.Not.Null);
+        Assert.That(patternGroup!.FilePaths, Has.Count.EqualTo(2));
+
+        var burstGroup = result.FirstOrDefault(g => g.BaseName.StartsWith("Burst_"));
+        Assert.That(burstGroup, Is.Not.Null);
+        Assert.That(burstGroup!.FilePaths, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void GroupFiles_ShouldSplitBurst_WhenHashThresholdExceeded() {
+        // Arrange
+        var baseTime = new DateTime(2025, 1, 1, 12, 0, 0);
+
+        // Time gap is within threshold (1 sec), but images are completely different (max hamming distance)
+        var files = new List<CachedPictureData> {
+            CreateCachedData(@"C:\Source\Seq_100.jpg", baseTime, 0),
+            CreateCachedData(@"C:\Source\Seq_101.jpg", baseTime.AddSeconds(1), ulong.MaxValue)
+        };
+
+        // Act
+        var result = _fileGrouper.GroupFiles(files);
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void GroupFiles_ShouldSplitBurst_WhenTimeThresholdExceeded() {
+        // Arrange
+        var baseTime = new DateTime(2025, 1, 1, 12, 0, 0);
+
+        // Exact same hash, but time gap is > 2 seconds
+        var files = new List<CachedPictureData> {
+            CreateCachedData(@"C:\Source\Seq_100.jpg", baseTime, 0),
+            CreateCachedData(@"C:\Source\Seq_101.jpg", baseTime.AddSeconds(3), 0)
+        };
+
+        // Act
+        var result = _fileGrouper.GroupFiles(files);
+
+        // Assert
+        Assert.That(result, Has.Count.EqualTo(2));
+        Assert.That(result[0].FilePaths, Has.Count.EqualTo(1));
+        Assert.That(result[1].FilePaths, Has.Count.EqualTo(1));
     }
 }

--- a/Graph/Infrastructure/Commands/ImportPicturesCommand.cs
+++ b/Graph/Infrastructure/Commands/ImportPicturesCommand.cs
@@ -32,12 +32,14 @@ public class ImportPicturesCommand : IImportPicturesCommand {
         _fileSystem = fileSystem;
         _pictureAnalyzer = pictureAnalyzer;
         _pictureProcessor = pictureProcessor;
-        _fileGrouper = new FileGrouper(fileSystem, pictureAnalyzer);
+
+        // Updated: FileGrouper now only needs the file system as it operates on cached DTOs
+        _fileGrouper = new FileGrouper(fileSystem);
     }
 
     public async Task<Album> ExecuteAsync(int? parentId, string albumName, string libraryPath, string sourcePath,
         IProgress<ImportProgress>? progress = null) {
-        // Task 1: Create the Album (Sub-folders are created by modified AlbumService)
+        // Task 1: Create the Album
         var album = await _albumService.CreateAsync(parentId, albumName, libraryPath);
         var albumPath = _fileSystem.Path.Combine(libraryPath, album.Uuid);
 
@@ -46,104 +48,161 @@ public class ImportPicturesCommand : IImportPicturesCommand {
         var thumbnailsPath = _fileSystem.Path.Combine(albumPath, "Thumbnails");
         var pickedPath = _fileSystem.Path.Combine(albumPath, "Picked");
 
-        // Task 2: Group files
-        var groups = await _fileGrouper.GroupFilesAsync(sourcePath);
-        var totalCount = groups.Count;
+        // Ensure directories exist
+        _fileSystem.Directory.CreateDirectory(rawsPath);
+        _fileSystem.Directory.CreateDirectory(jpgsPath);
+        _fileSystem.Directory.CreateDirectory(thumbnailsPath);
+
+        // Task 2: Pre-calculation & Caching Phase
+        var allFiles = _fileSystem.Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories)
+            .Where(f => !f.StartsWith('.') && !f.StartsWith("._"))
+            .ToList();
+
+        // Pair RAW+JPG by name early to avoid double-hashing the same picture
+        var preGroupedByName = allFiles.GroupBy(f => _fileSystem.Path.GetFileNameWithoutExtension(f)).ToList();
+        var cachedDataList = new List<CachedPictureData>(); // Assumes this DTO is defined in your domain
+
+        var preProcessCount = 0;
+        foreach (var pair in preGroupedByName) {
+            preProcessCount++;
+            progress?.Report(new ImportProgress(preProcessCount, preGroupedByName.Count,
+                $"Analyzing metadata for {pair.Key}..."));
+
+            // Prefer JPG for faster hashing, fallback to RAW
+            var fileToHash = pair.FirstOrDefault(f =>
+                                 JpgExtensions.Contains(_fileSystem.Path.GetExtension(f).ToUpperInvariant()))
+                             ?? pair.First();
+
+            var hashResult = await _pictureAnalyzer.CalculateHashAsync(fileToHash);
+            var timeResult = await _pictureAnalyzer.ExtractTimestamp(fileToHash);
+
+            if (hashResult.IsError) {
+                continue;
+            }
+
+            var primaryDate = timeResult is { IsError: false }
+                ? timeResult.Value
+                : _fileSystem.File.GetCreationTime(fileToHash);
+
+            // Add all files in this pair (RAW and JPG) to the cache list sharing the same hash and date
+            foreach (var file in pair) {
+                cachedDataList.Add(new CachedPictureData {
+                    FilePath = file,
+                    PrimaryDate = primaryDate,
+                    PHash = hashResult.Value
+                });
+            }
+        }
+
+        // Task 3: Burst Grouping (In-Memory, O(N))
+        var groups = _fileGrouper.GroupFiles(cachedDataList);
+
+        // Count total unique images (pairs) across all burst groups for accurate progress reporting
+        var totalImageCount = groups.Sum(g =>
+            g.FilePaths.GroupBy(f => _fileSystem.Path.GetFileNameWithoutExtension(f)).Count());
         var processedCount = 0;
 
+        // Task 4: Import Process
         foreach (var group in groups) {
-            processedCount++;
-            var currentFile = group.BaseName;
-            progress?.Report(new ImportProgress(processedCount, totalCount, currentFile));
+            // A group might be a single photo, OR a burst containing multiple distinct photos.
+            // We group by original base name again to identify the RAW+JPG pairs *within* the burst.
+            var filePairsWithinBurst = group.FilePaths
+                .GroupBy(f => _fileSystem.Path.GetFileNameWithoutExtension(f))
+                .ToList();
 
-            // Task 4: Implementation of naming convention
-            var baseFileName = group.PrimaryDate.ToString("yyyy-MM-dd_HH-mm-ss");
+            var burstIndex = 1;
+            var isBurst = filePairsWithinBurst.Count > 1;
 
-            // Task 3: Classify files
-            var rawFile = group.FilePaths.FirstOrDefault(f =>
-                RawExtensions.Contains(_fileSystem.Path.GetExtension(f).ToUpperInvariant()));
-            var jpgFile = group.FilePaths.FirstOrDefault(f =>
-                JpgExtensions.Contains(_fileSystem.Path.GetExtension(f).ToUpperInvariant()));
+            foreach (var pair in filePairsWithinBurst) {
+                processedCount++;
+                progress?.Report(new ImportProgress(processedCount, totalImageCount, $"Importing {pair.Key}"));
 
-            // Task 4: Collision Handling for naming
-            var finalFileName = baseFileName;
-            var counter = 1;
-            while (_fileSystem.File.Exists(_fileSystem.Path.Combine(jpgsPath, finalFileName + ".jpg")) ||
-                   _fileSystem.File.Exists(_fileSystem.Path.Combine(rawsPath,
-                       finalFileName + _fileSystem.Path.GetExtension(rawFile ?? "")))) {
-                finalFileName = $"{baseFileName}_{counter++}";
-            }
+                var rawFile = pair.FirstOrDefault(f =>
+                    RawExtensions.Contains(_fileSystem.Path.GetExtension(f).ToUpperInvariant()));
+                var jpgFile = pair.FirstOrDefault(f =>
+                    JpgExtensions.Contains(_fileSystem.Path.GetExtension(f).ToUpperInvariant()));
 
-            string? importedJpgPath = null;
-            string? importedRawPath = null;
+                var analysisFile = jpgFile ?? rawFile;
+                if (analysisFile == null) {
+                    continue;
+                }
 
-            if (rawFile != null) {
-                var extension = _fileSystem.Path.GetExtension(rawFile);
-                importedRawPath = _fileSystem.Path.Combine(rawsPath, finalFileName + extension);
-                _fileSystem.File.Copy(rawFile, importedRawPath);
-            }
+                // We get the hash from the pre-calculation to save time
+                var cachedData = cachedDataList.First(c => c.FilePath == analysisFile);
+                var pHash = cachedData.PHash;
 
-            // Task 3: IPictureAnalyzer to get metrics
-            var analysisFile = jpgFile ?? rawFile;
-            if (analysisFile == null) {
-                continue;
-            }
+                // Check for duplicates before doing expensive processing
+                if (await _nodeService.IsPictureHashDuplicateAsync(album.Id, pHash)) {
+                    continue;
+                }
 
-            var hashResult = await _pictureAnalyzer.CalculateHashAsync(analysisFile);
-            var sharpnessResult = await _pictureAnalyzer.CalculateSharpnessAsync(analysisFile);
+                // Calculate sharpness here so we only run it on files that aren't duplicates
+                var sharpnessResult = await _pictureAnalyzer.CalculateSharpnessAsync(analysisFile);
+                if (sharpnessResult.IsError) {
+                    continue;
+                }
 
-            // Abort if metadata extraction fails. We do not want 0-value records in the DB.
-            if (hashResult.IsError || sharpnessResult.IsError) {
-                continue;
-            }
+                // Naming Convention: Append a burst suffix if this is part of a high-speed sequence
+                var baseFileName = cachedData.PrimaryDate.ToString("yyyy-MM-dd_HH-mm-ss");
+                if (isBurst) {
+                    baseFileName += $"_B{burstIndex++}";
+                }
 
-            // Prevent duplicate records for the same physical asset within the same album.
-            if (await _nodeService.IsPictureHashDuplicateAsync(album.Id, hashResult.Value)) {
-                continue;
-            }
+                // Collision Handling
+                var finalFileName = baseFileName;
+                var counter = 1;
+                while (_fileSystem.File.Exists(_fileSystem.Path.Combine(jpgsPath, finalFileName + ".jpg")) ||
+                       _fileSystem.File.Exists(_fileSystem.Path.Combine(rawsPath,
+                           finalFileName + _fileSystem.Path.GetExtension(rawFile ?? "")))) {
+                    finalFileName = $"{baseFileName}_{counter++}";
+                }
 
-            // Task 3: IPictureProcessor to generate a preview (auto-oriented)
-            // Preview Path (High Fidelity)
-            var previewResult =
-                await _pictureProcessor.GenerateProcessedImageAsync(analysisFile, 2400, 2400, KnownResamplers.Lanczos3);
-            if (previewResult is { IsError: false }) {
-                importedJpgPath = _fileSystem.Path.Combine(jpgsPath, finalFileName + ".jpg");
-                await using var stream = _fileSystem.File.OpenWrite(importedJpgPath);
-                await previewResult.Value.SaveAsJpegAsync(stream, new JpegEncoder { Quality = 99 });
-            } else if (jpgFile != null) {
-                // Fallback to simple copy if processing fails and we have a JPG
-                importedJpgPath = _fileSystem.Path.Combine(jpgsPath, finalFileName + ".jpg");
-                _fileSystem.File.Copy(jpgFile, importedJpgPath);
-            }
+                // Copy RAW
+                if (rawFile != null) {
+                    var extension = _fileSystem.Path.GetExtension(rawFile);
+                    var importedRawPath = _fileSystem.Path.Combine(rawsPath, finalFileName + extension);
+                    _fileSystem.File.Copy(rawFile, importedRawPath);
+                }
 
-            // Task 3: IPictureProcessor to generate a thumbnail (auto-oriented)
-            // Thumbnail Path (Fast Path)
-            var thumbnailResult =
-                await _pictureProcessor.GenerateProcessedImageAsync(analysisFile, 400, 400, KnownResamplers.Triangle);
-            if (thumbnailResult is { IsError: false }) {
-                var thumbnailFile = _fileSystem.Path.Combine(thumbnailsPath, finalFileName + ".jpg");
-                await using var stream = _fileSystem.File.OpenWrite(thumbnailFile);
-                await thumbnailResult.Value.SaveAsJpegAsync(stream, new JpegEncoder { Quality = 75 });
-            }
+                // Generate High-Fidelity Preview
+                var previewResult =
+                    await _pictureProcessor.GenerateProcessedImageAsync(analysisFile, 2400, 2400,
+                        KnownResamplers.Lanczos3);
+                if (previewResult is { IsError: false }) {
+                    var importedJpgPath = _fileSystem.Path.Combine(jpgsPath, finalFileName + ".jpg");
+                    await using var stream = _fileSystem.File.OpenWrite(importedJpgPath);
+                    await previewResult.Value.SaveAsJpegAsync(stream, new JpegEncoder { Quality = 99 });
+                } else if (jpgFile != null) {
+                    var importedJpgPath = _fileSystem.Path.Combine(jpgsPath, finalFileName + ".jpg");
+                    _fileSystem.File.Copy(jpgFile, importedJpgPath);
+                }
 
-            // Task 3: Persists a new Picture node via INodeService
-            var pictureNode = new Picture {
-                Name = finalFileName,
-                ParentId = album.Id,
-                Type = NodeType.Picture,
-                CapturedAt = group.PrimaryDate,
-                Hash = hashResult.IsError ? 0 : hashResult.Value,
-                Sharpness = sharpnessResult.IsError ? 0 : sharpnessResult.Value
-            };
+                // Generate Thumbnail
+                var thumbnailResult =
+                    await _pictureProcessor.GenerateProcessedImageAsync(analysisFile, 400, 400,
+                        KnownResamplers.Triangle);
+                if (thumbnailResult is { IsError: false }) {
+                    var thumbnailFile = _fileSystem.Path.Combine(thumbnailsPath, finalFileName + ".jpg");
+                    await using var stream = _fileSystem.File.OpenWrite(thumbnailFile);
+                    await thumbnailResult.Value.SaveAsJpegAsync(stream, new JpegEncoder { Quality = 75 });
+                }
 
-            await _nodeService.CreateNodeAsync(pictureNode);
-            
-            // The service already set pictureNode.Parent = album, which might trigger EF fix-up
-            // and add it to album.Children if they share the same context. 
-            // We check to avoid doubling.
-            album.Children ??= new List<Node>();
-            if (!album.Children.Contains(pictureNode)) {
-                album.Children.Add(pictureNode);
+                // Persist to Database
+                var pictureNode = new Picture {
+                    Name = finalFileName,
+                    ParentId = album.Id,
+                    Type = NodeType.Picture,
+                    CapturedAt = cachedData.PrimaryDate,
+                    Hash = pHash,
+                    Sharpness = sharpnessResult.Value
+                };
+
+                await _nodeService.CreateNodeAsync(pictureNode);
+
+                album.Children ??= new List<Node>();
+                if (!album.Children.Contains(pictureNode)) {
+                    album.Children.Add(pictureNode);
+                }
             }
         }
 

--- a/Graph/Infrastructure/Commands/ImportPicturesCommand.cs
+++ b/Graph/Infrastructure/Commands/ImportPicturesCommand.cs
@@ -75,6 +75,7 @@ public class ImportPicturesCommand : IImportPicturesCommand {
 
             var hashResult = await _pictureAnalyzer.CalculateHashAsync(fileToHash);
             var timeResult = await _pictureAnalyzer.ExtractTimestamp(fileToHash);
+            var dimensionResult = await _pictureAnalyzer.GetDimensionsAsync(fileToHash);
 
             if (hashResult.IsError) {
                 continue;
@@ -84,12 +85,17 @@ public class ImportPicturesCommand : IImportPicturesCommand {
                 ? timeResult.Value
                 : _fileSystem.File.GetCreationTime(fileToHash);
 
+            var width = dimensionResult is { IsError: false } ? dimensionResult.Value.Width : 0;
+            var height = dimensionResult is { IsError: false } ? dimensionResult.Value.Height : 0;
+
             // Add all files in this pair (RAW and JPG) to the cache list sharing the same hash and date
             foreach (var file in pair) {
                 cachedDataList.Add(new CachedPictureData {
                     FilePath = file,
                     PrimaryDate = primaryDate,
-                    PHash = hashResult.Value
+                    PHash = hashResult.Value,
+                    Width = width,
+                    Height = height
                 });
             }
         }
@@ -194,7 +200,9 @@ public class ImportPicturesCommand : IImportPicturesCommand {
                     Type = NodeType.Picture,
                     CapturedAt = cachedData.PrimaryDate,
                     Hash = pHash,
-                    Sharpness = sharpnessResult.Value
+                    Sharpness = sharpnessResult.Value,
+                    Width = cachedData.Width,
+                    Height = cachedData.Height
                 };
 
                 await _nodeService.CreateNodeAsync(pictureNode);

--- a/Graph/Infrastructure/Utilities/FileGrouper.cs
+++ b/Graph/Infrastructure/Utilities/FileGrouper.cs
@@ -1,50 +1,127 @@
 using System.IO.Abstractions;
+using System.Text.RegularExpressions;
 using Graph.Domain.Models;
-using PictureWorker.Domain.Interfaces;
 
 namespace Graph.Infrastructure.Utilities;
 
-public class FileGrouper(IFileSystem fileSystem, IPictureAnalyzer pictureAnalyzer) {
-    public async Task<List<FileGroup>> GroupFilesAsync(string sourcePath) {
-        if (!fileSystem.Directory.Exists(sourcePath)) {
+public class FileGrouper(IFileSystem fileSystem) {
+    private readonly TimeSpan _burstTimeThreshold = TimeSpan.FromSeconds(2);
+    private readonly int _pHashSimilarityThreshold = 10;
+
+    // You would pass in your cached data from your repository/database here
+    public List<FileGroup> GroupFiles(List<CachedPictureData> cachedFiles) {
+        if (cachedFiles == null || cachedFiles.Count == 0) {
             return [];
         }
 
-        var files = fileSystem.Directory.GetFiles(sourcePath);
-        var groups = new Dictionary<string, FileGroup>();
+        var finalGroups = new List<FileGroup>();
+        var ungroupedFiles = new List<CachedPictureData>(cachedFiles);
 
-        foreach (var filePath in files) {
-            var fileName = fileSystem.Path.GetFileName(filePath);
+        // PASS 1: Explicit Pattern Matching (Fastest)
+        var patternGroups = GroupByNamePattern(ungroupedFiles);
+        finalGroups.AddRange(patternGroups);
 
-            // Skip hidden/ghost files
-            if (fileName.StartsWith('.') || fileName.StartsWith("._")) {
-                continue;
-            }
+        // Remove pattern-grouped files from the pool
+        var groupedPaths = patternGroups.SelectMany(g => g.FilePaths).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        ungroupedFiles.RemoveAll(f => groupedPaths.Contains(f.FilePath));
 
-            var fileNameWithoutExtension = fileSystem.Path.GetFileNameWithoutExtension(filePath);
+        // PASS 2: Time & Hash Sliding Window (Now O(N) because data is cached)
+        var timeAndHashGroups = GroupByTimeAndHash(ungroupedFiles);
+        finalGroups.AddRange(timeAndHashGroups);
 
-            if (!groups.TryGetValue(fileNameWithoutExtension, out var group)) {
+        return finalGroups;
+    }
+
+    private List<FileGroup> GroupByNamePattern(List<CachedPictureData> files) {
+        var groups = new Dictionary<string, FileGroup>(StringComparer.OrdinalIgnoreCase);
+        var burstPattern = new Regex(@"^(.*?)(?:_BURST\d+|-\d+)(?=\.[^.]+$)", RegexOptions.IgnoreCase);
+
+        foreach (var file in files) {
+            var fileName = fileSystem.Path.GetFileName(file.FilePath);
+            var match = burstPattern.Match(fileName);
+
+            var groupKey = match.Success
+                ? match.Groups[1].Value
+                : fileSystem.Path.GetFileNameWithoutExtension(file.FilePath);
+
+            if (!groups.TryGetValue(groupKey, out var group)) {
                 group = new FileGroup {
-                    BaseName = fileNameWithoutExtension,
-                    PrimaryDate = fileSystem.File.GetCreationTime(filePath) // Default if metadata fails
+                    BaseName = groupKey,
+                    PrimaryDate = file.PrimaryDate // Inherit date from cache
                 };
-                groups.Add(fileNameWithoutExtension, group);
+                groups.Add(groupKey, group);
             }
 
-            group.FilePaths.Add(filePath);
+            group.FilePaths.Add(file.FilePath);
         }
 
-        // After grouping, try to find the best primary date for each group
-        foreach (var group in groups.Values) {
-            foreach (var filePath in group.FilePaths) {
-                var timestampResult = await pictureAnalyzer.ExtractTimestamp(filePath);
-                if (timestampResult is { IsError: false }) {
-                    group.PrimaryDate = timestampResult.Value;
-                    break; // Found a valid timestamp from metadata, move to next group
+        return groups.Values.Where(g => g.FilePaths.Count > 1).ToList();
+    }
+
+    private List<FileGroup> GroupByTimeAndHash(List<CachedPictureData> files) {
+        var finalGroups = new List<FileGroup>();
+        if (!files.Any()) {
+            return finalGroups;
+        }
+
+        // Sort chronologically using the cached dates
+        var sortedFiles = files.OrderBy(f => f.PrimaryDate).ToList();
+
+        var currentGroup = new FileGroup {
+            BaseName = "Burst_" + sortedFiles[0].PrimaryDate.ToString("yyyyMMdd_HHmmss"),
+            PrimaryDate = sortedFiles[0].PrimaryDate
+        };
+        currentGroup.FilePaths.Add(sortedFiles[0].FilePath);
+
+        var previousFile = sortedFiles[0];
+
+        for (var i = 1; i < sortedFiles.Count; i++) {
+            var currentFile = sortedFiles[i];
+            var timeDifference = currentFile.PrimaryDate - previousFile.PrimaryDate;
+
+            // Since Hash is cached, we evaluate Time and Hash simultaneously
+            if (timeDifference <= _burstTimeThreshold) {
+                var hammingDistance = CalculateHammingDistance(previousFile.PHash, currentFile.PHash);
+
+                if (hammingDistance <= _pHashSimilarityThreshold) {
+                    currentGroup.FilePaths.Add(currentFile.FilePath);
+                    previousFile = currentFile;
+                    continue; // Move to next file in the burst
                 }
             }
+
+            // If we reach here, the burst is broken. Save the old group and start a new one.
+            finalGroups.Add(currentGroup);
+
+            currentGroup = new FileGroup {
+                BaseName = "Burst_" + currentFile.PrimaryDate.ToString("yyyyMMdd_HHmmss"),
+                PrimaryDate = currentFile.PrimaryDate
+            };
+            currentGroup.FilePaths.Add(currentFile.FilePath);
+            previousFile = currentFile;
         }
 
-        return groups.Values.ToList();
+        // Add the trailing group
+        finalGroups.Add(currentGroup);
+
+        return finalGroups;
     }
+
+    private int CalculateHammingDistance(ulong hash1, ulong hash2) {
+        var xor = hash1 ^ hash2;
+        var distance = 0;
+        while (xor != 0) {
+            distance += 1;
+            xor &= xor - 1;
+        }
+
+        return distance;
+    }
+}
+
+// DTO representing what you pull from your database/cache BEFORE grouping
+public class CachedPictureData {
+    public string FilePath { get; set; } = string.Empty;
+    public DateTime PrimaryDate { get; set; }
+    public ulong PHash { get; set; }
 }

--- a/Graph/Infrastructure/Utilities/FileGrouper.cs
+++ b/Graph/Infrastructure/Utilities/FileGrouper.cs
@@ -124,4 +124,6 @@ public class CachedPictureData {
     public string FilePath { get; set; } = string.Empty;
     public DateTime PrimaryDate { get; set; }
     public ulong PHash { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
 }

--- a/PictureWorker/Domain/Interfaces/IPictureAnalyzer.cs
+++ b/PictureWorker/Domain/Interfaces/IPictureAnalyzer.cs
@@ -6,4 +6,5 @@ public interface IPictureAnalyzer {
     Task<ErrorOr<ulong>> CalculateHashAsync(string filePath);
     Task<ErrorOr<int>> CalculateSharpnessAsync(string filePath);
     Task<ErrorOr<DateTime>> ExtractTimestamp(string filePath);
+    Task<ErrorOr<(int Width, int Height)>> GetDimensionsAsync(string filePath);
 }

--- a/PictureWorker/Infrastructure/Services/PictureAnalyzerService.cs
+++ b/PictureWorker/Infrastructure/Services/PictureAnalyzerService.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using CoenM.ImageHash.HashAlgorithms;
 using ErrorOr;
 using MetadataExtractor;
@@ -30,7 +30,7 @@ public class PictureAnalyzerService : IPictureAnalyzer {
             return Error.Validation(
                 "Picture.InvalidFormat",
                 "The file is not a supported image format.");
-        } catch (Exception e) {
+        } catch (Exception) {
             return Error.Failure(
                 "Picture.ProcessingFailed",
                 "An unexpected error occurred while calculating the hash.");
@@ -86,7 +86,7 @@ public class PictureAnalyzerService : IPictureAnalyzer {
                 // Implicitly converts the int to ErrorOr<int>
                 return (int)mean.Val0;
             });
-        } catch (Exception e) {
+        } catch (Exception) {
             return Error.Failure(
                 "Picture.ProcessingFailed",
                 "An unexpected error occurred while calculating sharpness.");
@@ -127,11 +127,50 @@ public class PictureAnalyzerService : IPictureAnalyzer {
                     "Picture.MetadataNotFound",
                     "Could not find a valid creation timestamp in the image metadata.");
             });
-        } catch (Exception e) {
+        } catch (Exception) {
             // Log the error here if you have a logger injected
             return Error.Failure(
                 "Picture.MetadataExtractionFailed",
                 "An unexpected error occurred while extracting metadata.");
+        }
+    }
+
+    public async Task<ErrorOr<(int Width, int Height)>> GetDimensionsAsync(string filePath) {
+        if (!File.Exists(filePath)) {
+            return Error.NotFound(
+                "Picture.NotFound",
+                $"The file was not found at path: {filePath}");
+        }
+
+        try {
+            // Use ImageSharp's IdentifyAsync as it's very fast and efficient for just dimensions
+            var info = await Image.IdentifyAsync(filePath);
+            if (info == null) {
+                return Error.Validation("Picture.InvalidFormat", "Failed to identify image dimensions.");
+            }
+
+            var width = info.Width;
+            var height = info.Height;
+
+            // We need the orientation to know if we should swap width and height
+            // We use MetadataExtractor here as it's already working in this service
+            return await Task.Run<ErrorOr<(int Width, int Height)>>(() => {
+                var directories = ImageMetadataReader.ReadMetadata(filePath);
+                var ifd0Directory = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
+
+                if (ifd0Directory != null && ifd0Directory.TryGetInt32(ExifDirectoryBase.TagOrientation, out var orientation)) {
+                    // Orientation values 5-8 indicate the image is rotated 90 or 270 degrees
+                    if (orientation > 4) {
+                        return (height, width);
+                    }
+                }
+
+                return (width, height);
+            });
+        } catch (Exception) {
+            return Error.Failure(
+                "Picture.ProcessingFailed",
+                "An unexpected error occurred while extracting dimensions.");
         }
     }
 

--- a/Picturebot/ViewModels/AddAlbumDialogViewModel.cs
+++ b/Picturebot/ViewModels/AddAlbumDialogViewModel.cs
@@ -64,10 +64,29 @@ public partial class AddAlbumDialogViewModel : ViewModelBase {
                 return;
             }
 
-            var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions {
+            var options = new FolderPickerOpenOptions {
                 Title = "Select Source Directory",
                 AllowMultiple = false
-            });
+            };
+
+            // Try to set a valid starting location to avoid platform-specific initialization crashes
+            var startPath = SourcePath;
+            if (string.IsNullOrWhiteSpace(startPath) || !Directory.Exists(startPath)) {
+                startPath = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+                if (!Directory.Exists(startPath)) {
+                    startPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                }
+            }
+
+            if (Directory.Exists(startPath)) {
+                try {
+                    options.SuggestedStartLocation = await topLevel.StorageProvider.TryGetFolderFromPathAsync(startPath);
+                } catch (Exception ex) {
+                    Log.Debug(ex, "Could not set suggested start location for folder picker");
+                }
+            }
+
+            var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(options);
 
             if (folders.Any()) {
                 var selectedPath = folders[0].Path.LocalPath;

--- a/Picturebot/ViewModels/BatchImportAlbumsDialogViewModel.cs
+++ b/Picturebot/ViewModels/BatchImportAlbumsDialogViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Platform.Storage;
@@ -19,8 +20,8 @@ namespace Picturebot.ViewModels;
 
 public partial class BatchImportAlbumsDialogViewModel : ViewModelBase {
     private readonly IImportAlbumsService _importAlbumsService;
-    private readonly ISettingsService _settingsService;
     private readonly Action _onCompleted;
+    private readonly ISettingsService _settingsService;
 
     [ObservableProperty]
     private LocationItem? _selectedParent;
@@ -54,12 +55,34 @@ public partial class BatchImportAlbumsDialogViewModel : ViewModelBase {
     private async Task SelectSourcePathAsync() {
         try {
             var topLevel = MainWindow.Instance;
-            if (topLevel == null) return;
+            if (topLevel == null) {
+                return;
+            }
 
-            var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions {
+            var options = new FolderPickerOpenOptions {
                 Title = "Select Root Directory for Import",
                 AllowMultiple = false
-            });
+            };
+
+            // Try to set a valid starting location to avoid platform-specific initialization crashes
+            var startPath = SourcePath;
+            if (string.IsNullOrWhiteSpace(startPath) || !Directory.Exists(startPath)) {
+                startPath = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+                if (!Directory.Exists(startPath)) {
+                    startPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                }
+            }
+
+            if (Directory.Exists(startPath)) {
+                try {
+                    options.SuggestedStartLocation =
+                        await topLevel.StorageProvider.TryGetFolderFromPathAsync(startPath);
+                } catch (Exception ex) {
+                    Log.Debug(ex, "Could not set suggested start location for folder picker");
+                }
+            }
+
+            var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(options);
 
             if (folders.Any()) {
                 SourcePath = folders[0].Path.LocalPath;
@@ -103,7 +126,9 @@ public partial class BatchImportAlbumsDialogViewModel : ViewModelBase {
         }
     }
 
-    private bool CanStartImport() => !string.IsNullOrWhiteSpace(SourcePath);
+    private bool CanStartImport() {
+        return !string.IsNullOrWhiteSpace(SourcePath);
+    }
 
     [RelayCommand]
     private void Cancel() {

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -23,10 +23,10 @@ using SukiUI.Toasts;
 namespace Picturebot.ViewModels;
 
 public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMessage>, IRecipient<NodeCreatedMessage> {
+    private readonly ICurationQueue _curationQueue;
     private readonly IPictureGroupingService _groupingService;
     private readonly INavigationService _navigationService;
     private readonly INodeService _nodeService;
-    private readonly ICurationQueue _curationQueue;
     private readonly IPathService _pathService;
     private readonly ISettingsService _settingsService;
 
@@ -169,61 +169,72 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
     }
 
     private async Task ApplyBurstGrouping() {
-        if (_currentNode == null) {
+        if (_currentNode == null || PicturesList.Count == 0) {
             return;
         }
 
-        // Threshold 6 for > 90% similarity
-        var groups = await _groupingService.GroupSimilarPicturesAsync(_currentNode.Id, 6);
+        // --- Fetch configurable thresholds from the database/settings ---
+        var strictTimeThreshold = 1; //_settingsService.Current.BurstTimeThresholdSeconds;
+        var fallbackTimeThreshold = 5; //_settingsService.Current.BurstFallbackTimeThresholdSeconds;
+        var hashSimilarityThreshold = 8; //_settingsService.Current.BurstHashSimilarityThreshold;
 
-        if (groups.Count == 0) {
-            ApplyDateGrouping();
-            return;
+        // 1. Sort everything chronologically
+        var sortedPics = PicturesList.OrderBy(p => p.Picture.CapturedAt).ToList();
+
+        var burstGroups = new List<List<PictureItemViewModel>>();
+        var currentGroup = new List<PictureItemViewModel> { sortedPics[0] };
+
+        // 2. Sliding window to catch bursts
+        for (var i = 1; i < sortedPics.Count; i++) {
+            var currentPic = sortedPics[i];
+            var prevPic = currentGroup.Last();
+
+            var timeSpan = currentPic.Picture.CapturedAt - prevPic.Picture.CapturedAt;
+            var hammingDistance = CalculateHammingDistance(prevPic.Picture.Hash, currentPic.Picture.Hash);
+
+            if (timeSpan.TotalSeconds <= strictTimeThreshold ||
+                (timeSpan.TotalSeconds <= fallbackTimeThreshold && hammingDistance <= hashSimilarityThreshold)) {
+                currentGroup.Add(currentPic);
+            } else {
+                burstGroups.Add(currentGroup);
+                currentGroup = new List<PictureItemViewModel> { currentPic };
+            }
         }
+
+        burstGroups.Add(currentGroup);
 
         var groupIndex = 1;
-        var groupedIds = new HashSet<int>();
 
-        foreach (var group in groups) {
-            if (group.Count <= 1) {
-                continue;
-            }
-
-            var picVms = group.Select(p => {
-                    var vm = PicturesList.FirstOrDefault(vm => vm.Picture.Id == p.Id);
-                    if (vm != null) {
-                        groupedIds.Add(p.Id);
-                    }
-
-                    return vm;
-                }).Where(vm => vm != null).Cast<PictureItemViewModel>()
-                .OrderBy(vm => vm.Picture.CapturedAt)
-                .ToList();
-
-            if (picVms.Count == 0) {
-                continue;
-            }
-
-            var bestPic = picVms.OrderByDescending(vm => vm.Picture.Sharpness).FirstOrDefault();
+        // 3. Process ALL groups as burst groups (even singletons)
+        foreach (var group in burstGroups) {
+            // Mark the sharpest photo as the 'Best' (if it's a singleton, it automatically wins)
+            var bestPic = group.OrderByDescending(p => p.Picture.Sharpness).FirstOrDefault();
             if (bestPic != null) {
                 bestPic.IsBest = true;
             }
 
-            var header = $"Burst Group {groupIndex++} ({picVms.Count})";
-            var groupVm = new PictureGroupViewModel(header, header,
-                new ObservableCollection<PictureItemViewModel>(picVms), true);
-            GroupedPictures.Add(groupVm);
+            // Format the header dynamically depending on if it's a sequence or a single shot
+            var header = group.Count > 1
+                ? $"Burst {groupIndex} ({group.Count} photos)"
+                : $"Burst {groupIndex} (Single)";
+
+            groupIndex++;
+
+            // Pass 'true' to ensure the UI treats every single one as a burst group
+            GroupedPictures.Add(new PictureGroupViewModel(header, header,
+                new ObservableCollection<PictureItemViewModel>(group), true));
+        }
+    }
+
+    private int CalculateHammingDistance(ulong hash1, ulong hash2) {
+        var xor = hash1 ^ hash2;
+        var distance = 0;
+        while (xor != 0) {
+            distance += 1;
+            xor &= xor - 1;
         }
 
-        var unclassified = PicturesList.Where(vm => !groupedIds.Contains(vm.Picture.Id))
-            .OrderBy(vm => vm.Picture.CapturedAt)
-            .ToList();
-        if (unclassified.Count > 0) {
-            var header = $"Unclassified ({unclassified.Count})";
-            var groupVm = new PictureGroupViewModel("Unclassified", header,
-                new ObservableCollection<PictureItemViewModel>(unclassified));
-            GroupedPictures.Add(groupVm);
-        }
+        return distance;
     }
 
     [RelayCommand(CanExecute = nameof(CanPlayCarousel))]
@@ -277,7 +288,8 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
     [RelayCommand(CanExecute = nameof(CanPlayCarousel))]
     private void PlayCarousel() {
         var window = new CarouselWindow();
-        var carouselVm = new CarouselDialogViewModel(PicturesList, SelectedPicture, _nodeService, _curationQueue, window.Close);
+        var carouselVm =
+            new CarouselDialogViewModel(PicturesList, SelectedPicture, _nodeService, _curationQueue, window.Close);
         window.DataContext = carouselVm;
 
         if (MainWindow.Instance != null) {

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -168,44 +169,72 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
         }
     }
 
+    private Orientation GetOrientation(Picture p) {
+        if (p.Width > p.Height) {
+            return Orientation.Landscape;
+        }
+
+        if (p.Height > p.Width) {
+            return Orientation.Portrait;
+        }
+
+        return Orientation.Square;
+    }
+
+    private int CalculateHammingDistance(ulong h1, ulong h2) {
+        return BitOperations.PopCount(h1 ^ h2);
+    }
+
     private async Task ApplyBurstGrouping() {
         if (_currentNode == null || PicturesList.Count == 0) {
             return;
         }
 
-        // --- Fetch configurable thresholds from the database/settings ---
-        var strictTimeThreshold = 1; //_settingsService.Current.BurstTimeThresholdSeconds;
-        var fallbackTimeThreshold = 5; //_settingsService.Current.BurstFallbackTimeThresholdSeconds;
-        var hashSimilarityThreshold = 8; //_settingsService.Current.BurstHashSimilarityThreshold;
+        // 1. Fetch Config with safe fallbacks
+        var settings = _settingsService.Current;
+        var timeThreshold = settings.BurstTimeThresholdSeconds > 0 ? settings.BurstTimeThresholdSeconds : 3;
+        var fallbackThreshold = settings.BurstFallbackTimeThresholdSeconds > 0
+            ? settings.BurstFallbackTimeThresholdSeconds
+            : 10;
+        var hashThreshold = settings.BurstHashSimilarityThreshold > 0 ? settings.BurstHashSimilarityThreshold : 8;
 
-        // 1. Sort everything chronologically
+        // 2. Sort everything chronologically
         var sortedPics = PicturesList.OrderBy(p => p.Picture.CapturedAt).ToList();
 
         var burstGroups = new List<List<PictureItemViewModel>>();
-        var currentGroup = new List<PictureItemViewModel> { sortedPics[0] };
+        if (sortedPics.Count > 0) {
+            var currentGroup = new List<PictureItemViewModel> { sortedPics[0] };
 
-        // 2. Sliding window to catch bursts
-        for (var i = 1; i < sortedPics.Count; i++) {
-            var currentPic = sortedPics[i];
-            var prevPic = currentGroup.Last();
+            // 3. Sliding window to catch bursts
+            for (var i = 1; i < sortedPics.Count; i++) {
+                var currentPic = sortedPics[i];
+                var prevPic = sortedPics[i - 1];
 
-            var timeSpan = currentPic.Picture.CapturedAt - prevPic.Picture.CapturedAt;
-            var hammingDistance = CalculateHammingDistance(prevPic.Picture.Hash, currentPic.Picture.Hash);
+                var timeDiff = (currentPic.Picture.CapturedAt - prevPic.Picture.CapturedAt).TotalSeconds;
 
-            if (timeSpan.TotalSeconds <= strictTimeThreshold ||
-                (timeSpan.TotalSeconds <= fallbackTimeThreshold && hammingDistance <= hashSimilarityThreshold)) {
-                currentGroup.Add(currentPic);
-            } else {
-                burstGroups.Add(currentGroup);
-                currentGroup = new List<PictureItemViewModel> { currentPic };
+                // Condition A: Orientation must match exactly
+                var orientationMatches = GetOrientation(prevPic.Picture) == GetOrientation(currentPic.Picture);
+
+                // Condition B: Strict time OR (Fallback time AND Hash similarity)
+                var isSimilar = timeDiff <= timeThreshold ||
+                                (timeDiff <= fallbackThreshold &&
+                                 CalculateHammingDistance(prevPic.Picture.Hash, currentPic.Picture.Hash) <=
+                                 hashThreshold);
+
+                if (orientationMatches && isSimilar) {
+                    currentGroup.Add(currentPic);
+                } else {
+                    burstGroups.Add(currentGroup);
+                    currentGroup = new List<PictureItemViewModel> { currentPic };
+                }
             }
-        }
 
-        burstGroups.Add(currentGroup);
+            burstGroups.Add(currentGroup);
+        }
 
         var groupIndex = 1;
 
-        // 3. Process ALL groups as burst groups (even singletons)
+        // 4. Process ALL groups as burst groups (even singletons)
         foreach (var group in burstGroups) {
             // Mark the sharpest photo as the 'Best' (if it's a singleton, it automatically wins)
             var bestPic = group.OrderByDescending(p => p.Picture.Sharpness).FirstOrDefault();
@@ -214,27 +243,13 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
             }
 
             // Format the header dynamically depending on if it's a sequence or a single shot
-            var header = group.Count > 1
-                ? $"Burst {groupIndex} ({group.Count} photos)"
-                : $"Burst {groupIndex} (Single)";
-
-            groupIndex++;
+            var countSuffix = group.Count > 1 ? $"{group.Count} photos" : "Single";
+            var header = $"Burst {groupIndex++} ({countSuffix})";
 
             // Pass 'true' to ensure the UI treats every single one as a burst group
             GroupedPictures.Add(new PictureGroupViewModel(header, header,
                 new ObservableCollection<PictureItemViewModel>(group), true));
         }
-    }
-
-    private int CalculateHammingDistance(ulong hash1, ulong hash2) {
-        var xor = hash1 ^ hash2;
-        var distance = 0;
-        while (xor != 0) {
-            distance += 1;
-            xor &= xor - 1;
-        }
-
-        return distance;
     }
 
     [RelayCommand(CanExecute = nameof(CanPlayCarousel))]
@@ -402,6 +417,12 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
     [RelayCommand]
     private void NavigateToChild(Node node) {
         _navigationService.NavigateTo(node);
+    }
+
+    private enum Orientation {
+        Landscape,
+        Portrait,
+        Square
     }
 }
 

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -196,7 +196,7 @@ public partial class GalleryViewModel : ViewModelBase, IRecipient<NodeSelectedMe
         var fallbackThreshold = settings.BurstFallbackTimeThresholdSeconds > 0
             ? settings.BurstFallbackTimeThresholdSeconds
             : 10;
-        var hashThreshold = settings.BurstHashSimilarityThreshold > 0 ? settings.BurstHashSimilarityThreshold : 8;
+        var hashThreshold = settings.GroupingThreshold > 0 ? settings.GroupingThreshold : 8;
 
         // 2. Sort everything chronologically
         var sortedPics = PicturesList.OrderBy(p => p.Picture.CapturedAt).ToList();

--- a/Picturebot/ViewModels/SettingsDialogViewModel.cs
+++ b/Picturebot/ViewModels/SettingsDialogViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -17,6 +18,15 @@ namespace Picturebot.ViewModels;
 
 public partial class SettingsDialogViewModel : ViewModelBase {
     private readonly ISettingsService _settingsService;
+
+    [ObservableProperty]
+    private int _burstFallbackThreshold = 10;
+
+    [ObservableProperty]
+    private int _burstHashThreshold = 8;
+
+    [ObservableProperty]
+    private int _burstTimeThreshold = 3;
 
     [ObservableProperty]
     private int _clusterThreshold = 10;
@@ -55,6 +65,9 @@ public partial class SettingsDialogViewModel : ViewModelBase {
         var settings = _settingsService.Current;
         LibraryLocation = settings.LibraryPath ?? string.Empty;
         ClusterThreshold = settings.GroupingThreshold;
+        BurstTimeThreshold = settings.BurstTimeThresholdSeconds;
+        BurstFallbackThreshold = settings.BurstFallbackTimeThresholdSeconds;
+        BurstHashThreshold = settings.BurstHashSimilarityThreshold;
         LaunchFullScreen = settings.LaunchMaximized;
 
         ThemeIndex = settings.ThemeMode switch {
@@ -87,12 +100,31 @@ public partial class SettingsDialogViewModel : ViewModelBase {
                 return;
             }
 
-            var folders = await window.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions {
+            var options = new FolderPickerOpenOptions {
                 Title = "Select Library Location",
                 AllowMultiple = false
-            });
+            };
 
-            if (folders.Count > 0) {
+            // Try to set a valid starting location to avoid platform-specific initialization crashes
+            var startPath = LibraryLocation;
+            if (string.IsNullOrWhiteSpace(startPath) || !Directory.Exists(startPath)) {
+                startPath = Environment.GetFolderPath(Environment.SpecialFolder.MyPictures);
+                if (!Directory.Exists(startPath)) {
+                    startPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                }
+            }
+
+            if (Directory.Exists(startPath)) {
+                try {
+                    options.SuggestedStartLocation = await window.StorageProvider.TryGetFolderFromPathAsync(startPath);
+                } catch (Exception ex) {
+                    Log.Debug(ex, "Could not set suggested start location for folder picker");
+                }
+            }
+
+            var folders = await window.StorageProvider.OpenFolderPickerAsync(options);
+
+            if (folders != null && folders.Count > 0) {
                 LibraryLocation = folders[0].Path.LocalPath;
             }
         } catch (Exception ex) {
@@ -109,6 +141,9 @@ public partial class SettingsDialogViewModel : ViewModelBase {
         var settings = new SettingsModel {
             LibraryPath = LibraryLocation,
             GroupingThreshold = ClusterThreshold,
+            BurstTimeThresholdSeconds = BurstTimeThreshold,
+            BurstFallbackTimeThresholdSeconds = BurstFallbackThreshold,
+            BurstHashSimilarityThreshold = BurstHashThreshold,
             LaunchMaximized = LaunchFullScreen,
             ThemeMode = ThemeIndex switch {
                 0 => ThemeMode.Light,

--- a/Picturebot/ViewModels/SettingsDialogViewModel.cs
+++ b/Picturebot/ViewModels/SettingsDialogViewModel.cs
@@ -23,13 +23,10 @@ public partial class SettingsDialogViewModel : ViewModelBase {
     private int _burstFallbackThreshold = 10;
 
     [ObservableProperty]
-    private int _burstHashThreshold = 8;
-
-    [ObservableProperty]
     private int _burstTimeThreshold = 3;
 
     [ObservableProperty]
-    private int _clusterThreshold = 10;
+    private int _groupingThreshold = 10;
 
     [ObservableProperty]
     private bool _launchFullScreen;
@@ -64,10 +61,9 @@ public partial class SettingsDialogViewModel : ViewModelBase {
 
         var settings = _settingsService.Current;
         LibraryLocation = settings.LibraryPath ?? string.Empty;
-        ClusterThreshold = settings.GroupingThreshold;
+        GroupingThreshold = settings.GroupingThreshold;
         BurstTimeThreshold = settings.BurstTimeThresholdSeconds;
         BurstFallbackThreshold = settings.BurstFallbackTimeThresholdSeconds;
-        BurstHashThreshold = settings.BurstHashSimilarityThreshold;
         LaunchFullScreen = settings.LaunchMaximized;
 
         ThemeIndex = settings.ThemeMode switch {
@@ -140,10 +136,9 @@ public partial class SettingsDialogViewModel : ViewModelBase {
 
         var settings = new SettingsModel {
             LibraryPath = LibraryLocation,
-            GroupingThreshold = ClusterThreshold,
+            GroupingThreshold = GroupingThreshold,
             BurstTimeThresholdSeconds = BurstTimeThreshold,
             BurstFallbackTimeThresholdSeconds = BurstFallbackThreshold,
-            BurstHashSimilarityThreshold = BurstHashThreshold,
             LaunchMaximized = LaunchFullScreen,
             ThemeMode = ThemeIndex switch {
                 0 => ThemeMode.Light,

--- a/Picturebot/Views/SettingsDialog.axaml
+++ b/Picturebot/Views/SettingsDialog.axaml
@@ -78,6 +78,42 @@
         </StackPanel>
 
         <StackPanel Spacing="10">
+            <TextBlock Text="BURST TIME THRESHOLD (SECONDS)" FontSize="11" FontWeight="Bold"
+                       Foreground="{DynamicResource SukiLowText}" LetterSpacing="1" />
+            <NumericUpDown Value="{Binding BurstTimeThreshold}"
+                           Minimum="1"
+                           Maximum="60"
+                           FormatString="0"
+                           HorizontalAlignment="Left"
+                           Width="120"
+                           Height="40" />
+        </StackPanel>
+
+        <StackPanel Spacing="10">
+            <TextBlock Text="BURST FALLBACK TIME (SECONDS)" FontSize="11" FontWeight="Bold"
+                       Foreground="{DynamicResource SukiLowText}" LetterSpacing="1" />
+            <NumericUpDown Value="{Binding BurstFallbackThreshold}"
+                           Minimum="1"
+                           Maximum="120"
+                           FormatString="0"
+                           HorizontalAlignment="Left"
+                           Width="120"
+                           Height="40" />
+        </StackPanel>
+
+        <StackPanel Spacing="10">
+            <TextBlock Text="BURST HASH THRESHOLD" FontSize="11" FontWeight="Bold"
+                       Foreground="{DynamicResource SukiLowText}" LetterSpacing="1" />
+            <NumericUpDown Value="{Binding BurstHashThreshold}"
+                           Minimum="1"
+                           Maximum="64"
+                           FormatString="0"
+                           HorizontalAlignment="Left"
+                           Width="120"
+                           Height="40" />
+        </StackPanel>
+
+        <StackPanel Spacing="10">
             <TextBlock Text="WINDOW" FontSize="11" FontWeight="Bold" Foreground="{DynamicResource SukiLowText}"
                        LetterSpacing="1" />
             <CheckBox IsChecked="{Binding LaunchFullScreen}"

--- a/Picturebot/Views/SettingsDialog.axaml
+++ b/Picturebot/Views/SettingsDialog.axaml
@@ -66,9 +66,9 @@
         </StackPanel>
 
         <StackPanel Spacing="10">
-            <TextBlock Text="CLUSTER THRESHOLD" FontSize="11" FontWeight="Bold"
+            <TextBlock Text="GROUPING THRESHOLD" FontSize="11" FontWeight="Bold"
                        Foreground="{DynamicResource SukiLowText}" LetterSpacing="1" />
-            <NumericUpDown Value="{Binding ClusterThreshold}"
+            <NumericUpDown Value="{Binding GroupingThreshold}"
                            Minimum="1"
                            Maximum="100"
                            FormatString="0"
@@ -95,18 +95,6 @@
             <NumericUpDown Value="{Binding BurstFallbackThreshold}"
                            Minimum="1"
                            Maximum="120"
-                           FormatString="0"
-                           HorizontalAlignment="Left"
-                           Width="120"
-                           Height="40" />
-        </StackPanel>
-
-        <StackPanel Spacing="10">
-            <TextBlock Text="BURST HASH THRESHOLD" FontSize="11" FontWeight="Bold"
-                       Foreground="{DynamicResource SukiLowText}" LetterSpacing="1" />
-            <NumericUpDown Value="{Binding BurstHashThreshold}"
-                           Minimum="1"
-                           Maximum="64"
                            FormatString="0"
                            HorizontalAlignment="Left"
                            Width="120"


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- Removed the `BurstHashSimilarityThreshold` property and adjusted the grouping logic and bindings accordingly.
- Added support for burst grouping thresholds and picture dimensions. Enhanced `GalleryViewModel` to incorporate orientation-aware burst grouping logic.
- Refactored `FileGrouper` to utilize cached data for improved performance and optimized grouping based on pattern, time, and hash. Introduced tests to cover various edge cases.

### Checklist

- [ ] Tests have been added or updated where necessary.
- [ ] Documentation has been updated as needed.
- [ ] Code changes follow project guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Picture dimensions (width and height) are now captured and stored
  * Added configurable burst grouping thresholds in settings: "Burst Time Threshold" and "Burst Fallback Time Threshold"

* **Improvements**
  * Enhanced picture grouping logic with improved burst detection
  * Updated grouping threshold default value for better organization
  * Renamed grouping threshold setting in the UI for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->