### PR TITLE
fix: reset `IsBurstViewEnabled` in `UpdateGalleryItems`; bump version to 1.2.10

### DIFF
--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.2.9</Version>
+        <Version>1.2.10</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -370,6 +370,8 @@ public partial class GalleryViewModel : ViewModelBase,
 
     private void UpdateGalleryItems(Node? currentNode, List<Node>? children) {
         _currentNode = currentNode;
+        IsBurstViewEnabled = false;
+
         // Clear collections to prevent ghosting
         Items.Clear();
         FolderItems.Clear();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed burst view state persistence issue. The view now properly resets when gallery items are updated, preventing visual inconsistencies during gallery navigation and refresh operations.

* **Chores**
  * Updated application version to 1.2.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->