### PR TITLE
feat: display burst group names in Carousel view, add `GroupName` support to view models, and bump version to 1.2.12

### DIFF
--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.2.11</Version>
+        <Version>1.2.12</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/CarouselDialogViewModel.cs
+++ b/Picturebot/ViewModels/CarouselDialogViewModel.cs
@@ -34,6 +34,9 @@ public partial class CarouselDialogViewModel : ViewModelBase {
     private PictureItemViewModel _currentPicture;
 
     [ObservableProperty]
+    private string? _currentGroupName;
+
+    [ObservableProperty]
     private ObservableCollection<Bitmap?> _previews = new();
 
     [ObservableProperty]
@@ -64,6 +67,7 @@ public partial class CarouselDialogViewModel : ViewModelBase {
     private void UpdateState() {
         CounterText = $"{CurrentIndex + 1} / {_pictures.Count}";
         Sharpness = CurrentPicture.Picture.Sharpness;
+        CurrentGroupName = CurrentPicture.GroupName;
         _ = LoadNearbyPreviewsAsync();
     }
 

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -193,6 +193,11 @@ public partial class GalleryViewModel : ViewModelBase,
             var count = group.Count();
             var header = $"{dateStr} ({count})";
             var sortedGroup = group.OrderBy(p => p.Picture.CapturedAt);
+            
+            foreach (var pic in sortedGroup) {
+                pic.GroupName = null;
+            }
+
             var groupVm = new PictureGroupViewModel(dateStr, header,
                 new ObservableCollection<PictureItemViewModel>(sortedGroup));
             GroupedPictures.Add(groupVm);
@@ -275,6 +280,10 @@ public partial class GalleryViewModel : ViewModelBase,
             // Format the header dynamically depending on if it's a sequence or a single shot
             var countSuffix = group.Count > 1 ? $"{group.Count} photos" : "Single";
             var header = $"Burst {groupIndex++} ({countSuffix})";
+
+            foreach (var pic in group) {
+                pic.GroupName = header;
+            }
 
             // Pass 'true' to ensure the UI treats every single one as a burst group
             GroupedPictures.Add(new PictureGroupViewModel(header, header,

--- a/Picturebot/ViewModels/PictureItemViewModel.cs
+++ b/Picturebot/ViewModels/PictureItemViewModel.cs
@@ -29,6 +29,9 @@ public partial class PictureItemViewModel : ViewModelBase, IDisposable {
     [ObservableProperty]
     private Bitmap? _thumbnail;
 
+    [ObservableProperty]
+    private string? _groupName;
+
     public PictureItemViewModel(Picture picture) {
         Picture = picture;
         _curationStatus = picture.CurationStatus;

--- a/Picturebot/Views/CarouselWindow.axaml
+++ b/Picturebot/Views/CarouselWindow.axaml
@@ -43,7 +43,8 @@
 
         <StackPanel HorizontalAlignment="Right"
                     VerticalAlignment="Top"
-                    Margin="30" Spacing="10" ZIndex="100">
+                    Margin="30" Spacing="12" ZIndex="100">
+            <!-- Main Metadata Badge -->
             <Border Background="#CC000000" CornerRadius="20" Padding="20,10" BorderBrush="#33FFFFFF"
                     BorderThickness="1">
                 <StackPanel Orientation="Horizontal" Spacing="20">
@@ -54,6 +55,19 @@
                     <TextBlock Text="{Binding Sharpness, StringFormat='Sharpness: {0}'}"
                                FontSize="18"
                                Foreground="White" FontWeight="SemiBold" />
+                </StackPanel>
+            </Border>
+
+            <!-- Burst Context Badge (Secondary) -->
+            <Border Background="#CC000000" CornerRadius="15" Padding="15,8" BorderBrush="#33FFFFFF"
+                    BorderThickness="1"
+                    HorizontalAlignment="Right"
+                    IsVisible="{Binding CurrentGroupName, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <icons:MaterialIcon Kind="BurstMode" Width="18" Height="18" Foreground="White" />
+                    <TextBlock Text="{Binding CurrentGroupName}"
+                               FontSize="16"
+                               Foreground="White" FontWeight="Bold" />
                 </StackPanel>
             </Border>
         </StackPanel>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a context badge in the carousel view that displays group information for photos, providing visual indication when browsing burst or grouped collections.

* **Chores**
  * Version bump to 1.2.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->