### PR TITLE
feat: add keyboard shortcuts for curation status updates in `GalleryView` and `CarouselWindow`, implement `SetCurationStatus` command in `GalleryViewModel`, and bump version to 1.2.13

### DIFF
--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.2.12</Version>
+        <Version>1.2.13</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -464,6 +464,22 @@ public partial class GalleryViewModel : ViewModelBase,
         _navigationService.NavigateTo(node);
     }
 
+    [RelayCommand]
+    private async Task SetCurationStatus(CurationStatus status) {
+        if (SelectedPicture == null) {
+            return;
+        }
+
+        try {
+            SelectedPicture.Picture.CurationStatus = status;
+            SelectedPicture.CurationStatus = status;
+            _curationQueue.Enqueue(SelectedPicture.Picture);
+            await Task.CompletedTask;
+        } catch (Exception ex) {
+            Log.Error(ex, "Failed to update curation status in gallery for {Name}", SelectedPicture.Name);
+        }
+    }
+
     public void Receive(ProcessingProgressMessage message) {
         if (_currentNode?.Id != message.Value.AlbumId) {
             return;

--- a/Picturebot/Views/CarouselWindow.axaml.cs
+++ b/Picturebot/Views/CarouselWindow.axaml.cs
@@ -29,6 +29,18 @@ public partial class CarouselWindow : Window {
                 vm.NextCommand.Execute(null);
                 e.Handled = true;
                 break;
+            case Key.P:
+                vm.SetCurationStatusCommand.Execute(Domain.Enums.CurationStatus.Flagged);
+                e.Handled = true;
+                break;
+            case Key.X:
+                vm.SetCurationStatusCommand.Execute(Domain.Enums.CurationStatus.Rejected);
+                e.Handled = true;
+                break;
+            case Key.U:
+                vm.SetCurationStatusCommand.Execute(Domain.Enums.CurationStatus.Unflagged);
+                e.Handled = true;
+                break;
         }
     }
 }

--- a/Picturebot/Views/GalleryView.axaml
+++ b/Picturebot/Views/GalleryView.axaml
@@ -8,9 +8,16 @@
              xmlns:suki="clr-namespace:SukiUI.Controls;assembly=SukiUI"
              xmlns:converters="using:Picturebot.Converters"
              xmlns:controls="using:Picturebot.Controls"
+             xmlns:enums="using:Domain.Enums"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Picturebot.Views.GalleryView"
              x:DataType="vm:GalleryViewModel">
+
+    <UserControl.KeyBindings>
+        <KeyBinding Gesture="P" Command="{Binding SetCurationStatusCommand}" CommandParameter="{x:Static enums:CurationStatus.Flagged}" />
+        <KeyBinding Gesture="X" Command="{Binding SetCurationStatusCommand}" CommandParameter="{x:Static enums:CurationStatus.Rejected}" />
+        <KeyBinding Gesture="U" Command="{Binding SetCurationStatusCommand}" CommandParameter="{x:Static enums:CurationStatus.Unflagged}" />
+    </UserControl.KeyBindings>
 
     <UserControl.Resources>
         <converters:NodeTypeToBooleanConverter x:Key="NodeTypeToBooleanConverter" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for managing picture curation status: press **P** to flag, **X** to reject, or **U** to mark as unflagged for streamlined workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->