### PR TITLE
feat: add burst grouping details to `PictureItemViewModel` and `GalleryViewModel`, update carousel view to display burst info, and bump version to 1.2.14

### DIFF
--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.2.13</Version>
+        <Version>1.2.14</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/CarouselDialogViewModel.cs
+++ b/Picturebot/ViewModels/CarouselDialogViewModel.cs
@@ -67,7 +67,13 @@ public partial class CarouselDialogViewModel : ViewModelBase {
     private void UpdateState() {
         CounterText = $"{CurrentIndex + 1} / {_pictures.Count}";
         Sharpness = CurrentPicture.Picture.Sharpness;
-        CurrentGroupName = CurrentPicture.GroupName;
+
+        if (CurrentPicture.BurstTotal > 1) {
+            CurrentGroupName = $"Burst {CurrentPicture.BurstIndex} ({CurrentPicture.BurstPosition}/{CurrentPicture.BurstTotal})";
+        } else {
+            CurrentGroupName = CurrentPicture.GroupName;
+        }
+
         _ = LoadNearbyPreviewsAsync();
     }
 

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -196,6 +196,9 @@ public partial class GalleryViewModel : ViewModelBase,
             
             foreach (var pic in sortedGroup) {
                 pic.GroupName = null;
+                pic.BurstIndex = 0;
+                pic.BurstPosition = 0;
+                pic.BurstTotal = 0;
             }
 
             var groupVm = new PictureGroupViewModel(dateStr, header,
@@ -279,11 +282,17 @@ public partial class GalleryViewModel : ViewModelBase,
 
             // Format the header dynamically depending on if it's a sequence or a single shot
             var countSuffix = group.Count > 1 ? $"{group.Count} photos" : "Single";
-            var header = $"Burst {groupIndex++} ({countSuffix})";
+            var header = $"Burst {groupIndex} ({countSuffix})";
 
+            var position = 1;
             foreach (var pic in group) {
                 pic.GroupName = header;
+                pic.BurstIndex = groupIndex;
+                pic.BurstPosition = position++;
+                pic.BurstTotal = group.Count;
             }
+
+            groupIndex++;
 
             // Pass 'true' to ensure the UI treats every single one as a burst group
             GroupedPictures.Add(new PictureGroupViewModel(header, header,

--- a/Picturebot/ViewModels/PictureItemViewModel.cs
+++ b/Picturebot/ViewModels/PictureItemViewModel.cs
@@ -32,6 +32,15 @@ public partial class PictureItemViewModel : ViewModelBase, IDisposable {
     [ObservableProperty]
     private string? _groupName;
 
+    [ObservableProperty]
+    private int _burstIndex;
+
+    [ObservableProperty]
+    private int _burstPosition;
+
+    [ObservableProperty]
+    private int _burstTotal;
+
     public PictureItemViewModel(Picture picture) {
         Picture = picture;
         _curationStatus = picture.CurationStatus;

--- a/Picturebot/Views/CarouselWindow.axaml
+++ b/Picturebot/Views/CarouselWindow.axaml
@@ -64,10 +64,11 @@
                     HorizontalAlignment="Right"
                     IsVisible="{Binding CurrentGroupName, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
                 <StackPanel Orientation="Horizontal" Spacing="10">
-                    <icons:MaterialIcon Kind="BurstMode" Width="18" Height="18" Foreground="White" />
+                    <icons:MaterialIcon Kind="BurstMode" Width="18" Height="18" Foreground="White" VerticalAlignment="Center" />
                     <TextBlock Text="{Binding CurrentGroupName}"
                                FontSize="16"
-                               Foreground="White" FontWeight="Bold" />
+                               Foreground="White" FontWeight="Bold"
+                               VerticalAlignment="Center" />
                 </StackPanel>
             </Border>
         </StackPanel>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced burst sequence display showing position within photo bursts (e.g., "Burst 1 (2/5)").

* **Bug Fixes**
  * Improved visual alignment and consistency of carousel display elements.

* **Chores**
  * Version bumped to 1.2.14.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tomekske/Picturebot/pull/38)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->