### PR TITLE
feat: add functionality to sync album curation status with 'Picked' folder, update related services, view, and ViewModel

### DIFF
--- a/Graph.Test/AlbumServiceTests.cs
+++ b/Graph.Test/AlbumServiceTests.cs
@@ -1,3 +1,4 @@
+using Database.Domain.Interfaces;
 using System.IO.Abstractions.TestingHelpers;
 using Database.Domain.Entities;
 using Domain.Enums;
@@ -14,6 +15,8 @@ public class AlbumServiceTests {
     private MockFileSystem _mockFileSystem;
     private Mock<INodeService> _mockNodeService;
     private Mock<ISettingsService> _mockSettingsService;
+    private Mock<IPictureRepository> _mockPictureRepository;
+    private Mock<IPathService> _mockPathService;
     private AlbumService _albumService;
 
     [SetUp]
@@ -21,12 +24,14 @@ public class AlbumServiceTests {
         _mockFileSystem = new MockFileSystem();
         _mockNodeService = new Mock<INodeService>();
         _mockSettingsService = new Mock<ISettingsService>();
+        _mockPictureRepository = new Mock<IPictureRepository>();
+        _mockPathService = new Mock<IPathService>();
         
         _mockSettingsService.Setup(s => s.Current).Returns(new SettingsModel {
             LibraryPath = @"C:\Photos"
         });
 
-        _albumService = new AlbumService(_mockNodeService.Object, _mockFileSystem, _mockSettingsService.Object);
+        _albumService = new AlbumService(_mockNodeService.Object, _mockFileSystem, _mockSettingsService.Object, _mockPictureRepository.Object, _mockPathService.Object);
 
         // Configure mock NodeService to simulate the strategy's Prepare behavior
         _mockNodeService

--- a/Graph/Domain/Interfaces/IAlbumService.cs
+++ b/Graph/Domain/Interfaces/IAlbumService.cs
@@ -16,4 +16,11 @@ public interface IAlbumService {
     Task<Album> CreateAsync(int? parentId, string albumName, string path);
 
     Task DeleteAsync(Album album);
+
+    /// <summary>
+    ///     Synchronizes the database curation status of pictures within the album based on the presence of files in the physical 'Picked' subfolder.
+    /// </summary>
+    /// <param name="album">The album to synchronize.</param>
+    /// <returns>A Task representing the asynchronous operation.</returns>
+    Task SyncPickedStatusAsync(Album album);
 }

--- a/Graph/Domain/Interfaces/INodeService.cs
+++ b/Graph/Domain/Interfaces/INodeService.cs
@@ -38,6 +38,8 @@ public interface INodeService {
     Task<List<Node>> LoadHydratedTreeAsync();
 
     Task<List<Node>> GetAllNodesAsync();
+    
+    Task<List<Node>> FindChildrenAsync(int parentId);
 
     /// <summary>
     ///     Updates an existing node's information within the hierarchy.

--- a/Graph/Domain/Interfaces/IPathService.cs
+++ b/Graph/Domain/Interfaces/IPathService.cs
@@ -5,4 +5,5 @@ namespace Graph.Domain.Interfaces;
 public interface IPathService {
     void PopulatePaths(Picture picture);
     void PopulatePaths(IEnumerable<Picture> pictures);
+    string? GetAlbumPickedPath(Album album);
 }

--- a/Graph/Infrastructure/Services/AlbumService.cs
+++ b/Graph/Infrastructure/Services/AlbumService.cs
@@ -1,5 +1,6 @@
 using System.IO.Abstractions;
 using Database.Domain.Entities;
+using Database.Domain.Interfaces;
 using Domain.Enums;
 using Domain.Interfaces;
 using Graph.Domain.Interfaces;
@@ -9,7 +10,9 @@ namespace Graph.Infrastructure.Services;
 public class AlbumService(
     INodeService nodeService,
     IFileSystem fileSystem,
-    ISettingsService settingsService) : IAlbumService {
+    ISettingsService settingsService,
+    IPictureRepository pictureRepository,
+    IPathService pathService) : IAlbumService {
     public async Task<Album> CreateAsync(int? parentId, string albumName, string path) {
         var album = new Album {
             Name = albumName,
@@ -63,5 +66,35 @@ public class AlbumService(
         }
 
         await nodeService.DeleteNodeAsync(album);
+    }
+
+    public async Task SyncPickedStatusAsync(Album album) {
+        var pickedPath = pathService.GetAlbumPickedPath(album);
+        if (string.IsNullOrEmpty(pickedPath) || !fileSystem.Directory.Exists(pickedPath)) {
+            return;
+        }
+
+        var pickedFiles = fileSystem.Directory.GetFiles(pickedPath);
+        var pickedFileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var file in pickedFiles) {
+            var fileNameWithoutExtension = fileSystem.Path.GetFileNameWithoutExtension(file);
+            pickedFileNames.Add(fileNameWithoutExtension);
+        }
+
+        var pictures = await pictureRepository.FindByHierarchyIdAsync(album.Id);
+
+        foreach (var picture in pictures) {
+            bool isPickedOnDisk = pickedFileNames.Contains(picture.Name);
+            bool isFlaggedInDb = picture.CurationStatus == CurationStatus.Flagged;
+
+            if (isPickedOnDisk && !isFlaggedInDb) {
+                picture.CurationStatus = CurationStatus.Flagged;
+                await pictureRepository.UpdateAsync(picture);
+            } else if (!isPickedOnDisk && isFlaggedInDb) {
+                picture.CurationStatus = CurationStatus.Unflagged;
+                await pictureRepository.UpdateAsync(picture);
+            }
+        }
     }
 }

--- a/Graph/Infrastructure/Services/NodeService.cs
+++ b/Graph/Infrastructure/Services/NodeService.cs
@@ -59,6 +59,10 @@ public class NodeService(
         return await nodeRepository.FindAllAsync();
     }
 
+    public async Task<List<Node>> FindChildrenAsync(int parentId) {
+        return await nodeRepository.FindChildrenAsync(parentId);
+    }
+
     public async Task UpdateNodeAsync(Node node) {
         await nodeRepository.UpdateAsync(node);
     }

--- a/Graph/Infrastructure/Services/PathService.cs
+++ b/Graph/Infrastructure/Services/PathService.cs
@@ -28,4 +28,12 @@ public class PathService(ISettingsService settingsService, IFileSystem fileSyste
             PopulatePaths(picture);
         }
     }
+
+    public string? GetAlbumPickedPath(Album album) {
+        if (string.IsNullOrEmpty(album.Uuid)) return null;
+        if (string.IsNullOrEmpty(settingsService.Current.LibraryPath)) return null;
+
+        var albumPath = fileSystem.Path.Combine(settingsService.Current.LibraryPath, album.Uuid);
+        return fileSystem.Path.Combine(albumPath, "Picked");
+    }
 }

--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.5.0</Version>
+        <Version>1.6.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -453,6 +453,32 @@ public partial class GalleryViewModel : ViewModelBase,
     }
 
     [RelayCommand(CanExecute = nameof(CanPlayCarousel))]
+    private async Task SyncCurationStatusWithPickedFolderAsync() {
+        if (_currentNode is not Album album) return;
+
+        try {
+            await _albumService.SyncPickedStatusAsync(album);
+
+            // Re-fetch children to get the updated entities and refresh the view
+            var children = await _nodeService.FindChildrenAsync(album.Id);
+            UpdateGalleryItems(album, children);
+            
+            MainWindow.ToastManager.CreateToast()
+                .WithTitle("Sync Complete")
+                .WithContent($"Successfully synchronized curation status with the Picked folder for '{album.Name}'.")
+                .Dismiss().After(TimeSpan.FromSeconds(3))
+                .Queue();
+        } catch (Exception ex) {
+            Log.Error(ex, "Failed to sync curation status with Picked folder for album {AlbumId}", album.Id);
+            MainWindow.ToastManager.CreateToast()
+                .WithTitle("Sync Error")
+                .WithContent("Failed to synchronize with Picked folder.")
+                .Dismiss().ByClicking()
+                .Queue();
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanPlayCarousel))]
     private void PlayCarousel() {
         var window = new CarouselWindow();
         var carouselVm =

--- a/Picturebot/Views/GalleryView.axaml
+++ b/Picturebot/Views/GalleryView.axaml
@@ -396,6 +396,23 @@
                     <Button Classes="Basic" ToolTip.Tip="Sort">
                         <icons:MaterialIcon Kind="SortVariant" Width="20" Height="20" />
                     </Button>
+                    <Separator Width="1" Height="20" Background="{DynamicResource SukiBorderBrush}" Margin="4,0" IsVisible="{Binding IsShowingAlbum}" />
+                    <Button Classes="Basic" ToolTip.Tip="Actions" IsVisible="{Binding IsShowingAlbum}">
+                        <StackPanel Orientation="Horizontal" Spacing="4">
+                            <icons:MaterialIcon Kind="LightningBolt" Width="20" Height="20" Foreground="{DynamicResource SukiPrimaryColor}" />
+                            <icons:MaterialIcon Kind="ChevronDown" Width="16" Height="16" />
+                        </StackPanel>
+                        <Button.Flyout>
+                            <MenuFlyout Placement="BottomEdgeAlignedLeft">
+                                <MenuItem Header="Sync Curation Status with 'Picked' Folder"
+                                          Command="{Binding SyncCurationStatusWithPickedFolderCommand}">
+                                    <MenuItem.Icon>
+                                        <icons:MaterialIcon Kind="FolderSyncOutline" Width="18" Height="18" />
+                                    </MenuItem.Icon>
+                                </MenuItem>
+                            </MenuFlyout>
+                        </Button.Flyout>
+                    </Button>
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="5" IsVisible="{Binding !IsLibraryRoot}">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Sync Curation Status with 'Picked' Folder" action for albums. This feature synchronizes the curation status of pictures in the database with files present in the album's "Picked" directory on disk, ensuring your database reflects the actual state of your picked files.

* **Chores**
  * Updated application version to 1.6.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tomekske/Picturebot/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->