### PR TITLE
fix: handle `OnKeyDown` events to ignore key presses when focusing text fields, bump version to 1.6.2

### DIFF
--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.6.1</Version>
+        <Version>1.6.2</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/Views/CarouselDialogView.axaml.cs
+++ b/Picturebot/Views/CarouselDialogView.axaml.cs
@@ -19,6 +19,12 @@ public partial class CarouselDialogView : UserControl {
     }
 
     protected override void OnKeyDown(KeyEventArgs e) {
+        var focusManager = TopLevel.GetTopLevel(this)?.FocusManager;
+        if (focusManager?.GetFocusedElement() is TextBox) {
+            base.OnKeyDown(e);
+            return;
+        }
+
         base.OnKeyDown(e);
 
         if (DataContext is not CarouselDialogViewModel vm) {

--- a/Picturebot/Views/CarouselWindow.axaml.cs
+++ b/Picturebot/Views/CarouselWindow.axaml.cs
@@ -12,6 +12,11 @@ public partial class CarouselWindow : Window {
     }
 
     protected override void OnKeyDown(KeyEventArgs e) {
+        if (FocusManager?.GetFocusedElement() is TextBox) {
+            base.OnKeyDown(e);
+            return;
+        }
+
         base.OnKeyDown(e);
 
         if (DataContext is not CarouselDialogViewModel vm) {

--- a/Picturebot/Views/GalleryView.axaml.cs
+++ b/Picturebot/Views/GalleryView.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Input;
 using Picturebot.ViewModels;
 
 namespace Picturebot.Views;
@@ -11,6 +12,15 @@ public partial class GalleryView : UserControl {
     public GalleryView(GalleryViewModel viewModel) {
         InitializeComponent();
         DataContext = viewModel;
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e) {
+        var focusManager = TopLevel.GetTopLevel(this)?.FocusManager;
+        if (focusManager?.GetFocusedElement() is TextBox) {
+            return;
+        }
+
+        base.OnKeyDown(e);
     }
 
     private void OnSelectionChanged(object? sender, SelectionChangedEventArgs e) {

--- a/Picturebot/Views/MainWindow.axaml.cs
+++ b/Picturebot/Views/MainWindow.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia.Controls;
 using Avalonia.Input;
 using Microsoft.Extensions.DependencyInjection;
 using Picturebot.Services;
@@ -19,6 +20,14 @@ public partial class MainWindow : SukiWindow {
     }
 
     public static MainWindow? Instance { get; private set; }
+
+    protected override void OnKeyDown(KeyEventArgs e) {
+        if (FocusManager?.GetFocusedElement() is TextBox) {
+            return;
+        }
+        
+        base.OnKeyDown(e);
+    }
 
     protected override void OnPointerPressed(PointerPressedEventArgs e) {
         base.OnPointerPressed(e);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed keyboard shortcuts being triggered while typing in text input fields, preventing interference with user text entry across the application.

* **Chores**
  * Updated application version to 1.6.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Tomekske/Picturebot/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->