### PR TITLE
Fix burst shot toggle

### DIFF
--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.6.4</Version>
+        <Version>1.6.5</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -267,7 +267,6 @@ public partial class GalleryViewModel : ViewModelBase,
 
     [RelayCommand]
     private async Task ToggleGroupingMode() {
-        IsBurstViewEnabled = !IsBurstViewEnabled;
         await RefreshGalleryGrouping();
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gallery grouping now refreshes immediately when toggling burst view mode, eliminating the need for manual refresh to see the updated view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->