### PR TITLE
Add XMP metadata support and refine legacy table handling

### DIFF
--- a/Database/Domain/Entities/Picture.cs
+++ b/Database/Domain/Entities/Picture.cs
@@ -48,16 +48,19 @@ public class Picture : Node {
     /// <summary>
     ///     The current curation state of the picture (e.g., Flagged, Rejected).
     /// </summary>
+    [NotMapped]
     public CurationStatus CurationStatus { get; set; } = CurationStatus.Unflagged;
 
     /// <summary>
     ///     The color label assigned to the picture.
     /// </summary>
+    [NotMapped]
     public ColorLabel ColorLabel { get; set; } = ColorLabel.None;
 
     /// <summary>
     ///     The star rating of the picture (0-5).
     /// </summary>
+    [NotMapped]
     public int Rating { get; set; }
 
     /// <summary>

--- a/Database/Infrastructure/Data/ApplicationDBContext.cs
+++ b/Database/Infrastructure/Data/ApplicationDBContext.cs
@@ -57,13 +57,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> dbConte
             .Property(n => n.Type)
             .HasConversion<string>();
 
-        modelBuilder.Entity<Picture>()
-            .Property(p => p.CurationStatus)
-            .HasConversion<string>();
 
-        modelBuilder.Entity<Picture>()
-            .Property(p => p.ColorLabel)
-            .HasConversion<string>();
 
         modelBuilder.Entity<Picture>()
             .Property(p => p.ProcessingState)

--- a/Database/Infrastructure/Repositories/NodeRepository.cs
+++ b/Database/Infrastructure/Repositories/NodeRepository.cs
@@ -65,16 +65,26 @@ public class NodeRepository(ApplicationDbContext context) : INodeRepository {
     public async Task UpdateAsync(Node node) {
         var trackedEntity = context.Nodes.Local.FirstOrDefault(n => n.Id == node.Id);
         
-        if (trackedEntity != null) {
-            // Update the properties of the tracked entity without replacing it
-            context.Entry(trackedEntity).CurrentValues.SetValues(node);
-        } else {
-            // Attach the node and mark as modified
-            context.Nodes.Attach(node);
-            context.Entry(node).State = EntityState.Modified;
+        var parent = node.Parent;
+        var children = node.Children;
+        node.Parent = null;
+        node.Children = null;
+
+        try {
+            if (trackedEntity != null) {
+                // Update the properties of the tracked entity without replacing it
+                context.Entry(trackedEntity).CurrentValues.SetValues(node);
+            } else {
+                // Attach the node and mark as modified
+                context.Nodes.Attach(node);
+                context.Entry(node).State = EntityState.Modified;
+            }
+            
+            await context.SaveChangesAsync();
+        } finally {
+            node.Parent = parent;
+            node.Children = children;
         }
-        
-        await context.SaveChangesAsync();
     }
 
     public async Task DeleteAsync(Node node) {

--- a/Database/Migrations/20260630200738_MakeLegacyColumnsNullable.Designer.cs
+++ b/Database/Migrations/20260630200738_MakeLegacyColumnsNullable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Database.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630200738_MakeLegacyColumnsNullable")]
+    partial class MakeLegacyColumnsNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.12");

--- a/Database/Migrations/20260630200738_MakeLegacyColumnsNullable.cs
+++ b/Database/Migrations/20260630200738_MakeLegacyColumnsNullable.cs
@@ -10,7 +10,7 @@ namespace Database.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("PRAGMA foreign_keys=OFF;");
+            migrationBuilder.Sql("PRAGMA foreign_keys=OFF;", suppressTransaction: true);
             
             migrationBuilder.Sql(@"
                 CREATE TABLE ""pictures_new"" (
@@ -28,22 +28,22 @@ namespace Database.Migrations
                     ""ColorLabel"" TEXT NULL,
                     ""Rating"" INTEGER NULL,
                     CONSTRAINT ""FK_pictures_nodes_Id"" FOREIGN KEY (""Id"") REFERENCES ""nodes"" (""Id"") ON DELETE CASCADE
-                );");
+                );", suppressTransaction: true);
 
             migrationBuilder.Sql(@"
                 INSERT INTO ""pictures_new"" (""Id"", ""CapturedAt"", ""Extension"", ""Hash"", ""Height"", ""LastErrorMessage"", ""ProcessingState"", ""RetryCount"", ""Sharpness"", ""Width"", ""CurationStatus"", ""ColorLabel"", ""Rating"")
                 SELECT ""Id"", ""CapturedAt"", ""Extension"", ""Hash"", ""Height"", ""LastErrorMessage"", ""ProcessingState"", ""RetryCount"", ""Sharpness"", ""Width"", ""CurationStatus"", ""ColorLabel"", ""Rating""
-                FROM ""pictures"";");
+                FROM ""pictures"";", suppressTransaction: true);
 
-            migrationBuilder.Sql("DROP TABLE \"pictures\";");
-            migrationBuilder.Sql("ALTER TABLE \"pictures_new\" RENAME TO \"pictures\";");
+            migrationBuilder.Sql("DROP TABLE \"pictures\";", suppressTransaction: true);
+            migrationBuilder.Sql("ALTER TABLE \"pictures_new\" RENAME TO \"pictures\";", suppressTransaction: true);
             
-            migrationBuilder.Sql("PRAGMA foreign_keys=ON;");
+            migrationBuilder.Sql("PRAGMA foreign_keys=ON;", suppressTransaction: true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("PRAGMA foreign_keys=OFF;");
+            migrationBuilder.Sql("PRAGMA foreign_keys=OFF;", suppressTransaction: true);
             
             migrationBuilder.Sql(@"
                 CREATE TABLE ""pictures_new"" (
@@ -61,7 +61,7 @@ namespace Database.Migrations
                     ""ColorLabel"" TEXT NOT NULL,
                     ""Rating"" INTEGER NOT NULL,
                     CONSTRAINT ""FK_pictures_nodes_Id"" FOREIGN KEY (""Id"") REFERENCES ""nodes"" (""Id"") ON DELETE CASCADE
-                );");
+                );", suppressTransaction: true);
 
             migrationBuilder.Sql(@"
                 INSERT INTO ""pictures_new"" (""Id"", ""CapturedAt"", ""Extension"", ""Hash"", ""Height"", ""LastErrorMessage"", ""ProcessingState"", ""RetryCount"", ""Sharpness"", ""Width"", ""CurationStatus"", ""ColorLabel"", ""Rating"")
@@ -69,12 +69,12 @@ namespace Database.Migrations
                        COALESCE(""CurationStatus"", 'Unflagged'), 
                        COALESCE(""ColorLabel"", 'None'), 
                        COALESCE(""Rating"", 0)
-                FROM ""pictures"";");
+                FROM ""pictures"";", suppressTransaction: true);
 
-            migrationBuilder.Sql("DROP TABLE \"pictures\";");
-            migrationBuilder.Sql("ALTER TABLE \"pictures_new\" RENAME TO \"pictures\";");
+            migrationBuilder.Sql("DROP TABLE \"pictures\";", suppressTransaction: true);
+            migrationBuilder.Sql("ALTER TABLE \"pictures_new\" RENAME TO \"pictures\";", suppressTransaction: true);
             
-            migrationBuilder.Sql("PRAGMA foreign_keys=ON;");
+            migrationBuilder.Sql("PRAGMA foreign_keys=ON;", suppressTransaction: true);
         }
     }
 }

--- a/Database/Migrations/20260630200738_MakeLegacyColumnsNullable.cs
+++ b/Database/Migrations/20260630200738_MakeLegacyColumnsNullable.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeLegacyColumnsNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("PRAGMA foreign_keys=OFF;");
+            
+            migrationBuilder.Sql(@"
+                CREATE TABLE ""pictures_new"" (
+                    ""Id"" INTEGER NOT NULL PRIMARY KEY,
+                    ""CapturedAt"" TEXT NOT NULL,
+                    ""Extension"" TEXT NULL,
+                    ""Hash"" INTEGER NOT NULL,
+                    ""Height"" INTEGER NOT NULL,
+                    ""LastErrorMessage"" TEXT NULL,
+                    ""ProcessingState"" TEXT NOT NULL,
+                    ""RetryCount"" INTEGER NOT NULL,
+                    ""Sharpness"" INTEGER NOT NULL,
+                    ""Width"" INTEGER NOT NULL,
+                    ""CurationStatus"" TEXT NULL,
+                    ""ColorLabel"" TEXT NULL,
+                    ""Rating"" INTEGER NULL,
+                    CONSTRAINT ""FK_pictures_nodes_Id"" FOREIGN KEY (""Id"") REFERENCES ""nodes"" (""Id"") ON DELETE CASCADE
+                );");
+
+            migrationBuilder.Sql(@"
+                INSERT INTO ""pictures_new"" (""Id"", ""CapturedAt"", ""Extension"", ""Hash"", ""Height"", ""LastErrorMessage"", ""ProcessingState"", ""RetryCount"", ""Sharpness"", ""Width"", ""CurationStatus"", ""ColorLabel"", ""Rating"")
+                SELECT ""Id"", ""CapturedAt"", ""Extension"", ""Hash"", ""Height"", ""LastErrorMessage"", ""ProcessingState"", ""RetryCount"", ""Sharpness"", ""Width"", ""CurationStatus"", ""ColorLabel"", ""Rating""
+                FROM ""pictures"";");
+
+            migrationBuilder.Sql("DROP TABLE \"pictures\";");
+            migrationBuilder.Sql("ALTER TABLE \"pictures_new\" RENAME TO \"pictures\";");
+            
+            migrationBuilder.Sql("PRAGMA foreign_keys=ON;");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("PRAGMA foreign_keys=OFF;");
+            
+            migrationBuilder.Sql(@"
+                CREATE TABLE ""pictures_new"" (
+                    ""Id"" INTEGER NOT NULL PRIMARY KEY,
+                    ""CapturedAt"" TEXT NOT NULL,
+                    ""Extension"" TEXT NULL,
+                    ""Hash"" INTEGER NOT NULL,
+                    ""Height"" INTEGER NOT NULL,
+                    ""LastErrorMessage"" TEXT NULL,
+                    ""ProcessingState"" TEXT NOT NULL,
+                    ""RetryCount"" INTEGER NOT NULL,
+                    ""Sharpness"" INTEGER NOT NULL,
+                    ""Width"" INTEGER NOT NULL,
+                    ""CurationStatus"" TEXT NOT NULL,
+                    ""ColorLabel"" TEXT NOT NULL,
+                    ""Rating"" INTEGER NOT NULL,
+                    CONSTRAINT ""FK_pictures_nodes_Id"" FOREIGN KEY (""Id"") REFERENCES ""nodes"" (""Id"") ON DELETE CASCADE
+                );");
+
+            migrationBuilder.Sql(@"
+                INSERT INTO ""pictures_new"" (""Id"", ""CapturedAt"", ""Extension"", ""Hash"", ""Height"", ""LastErrorMessage"", ""ProcessingState"", ""RetryCount"", ""Sharpness"", ""Width"", ""CurationStatus"", ""ColorLabel"", ""Rating"")
+                SELECT ""Id"", ""CapturedAt"", ""Extension"", ""Hash"", ""Height"", ""LastErrorMessage"", ""ProcessingState"", ""RetryCount"", ""Sharpness"", ""Width"", 
+                       COALESCE(""CurationStatus"", 'Unflagged'), 
+                       COALESCE(""ColorLabel"", 'None'), 
+                       COALESCE(""Rating"", 0)
+                FROM ""pictures"";");
+
+            migrationBuilder.Sql("DROP TABLE \"pictures\";");
+            migrationBuilder.Sql("ALTER TABLE \"pictures_new\" RENAME TO \"pictures\";");
+            
+            migrationBuilder.Sql("PRAGMA foreign_keys=ON;");
+        }
+    }
+}

--- a/Graph.Test/AlbumServiceTests.cs
+++ b/Graph.Test/AlbumServiceTests.cs
@@ -17,6 +17,7 @@ public class AlbumServiceTests {
     private Mock<ISettingsService> _mockSettingsService;
     private Mock<IPictureRepository> _mockPictureRepository;
     private Mock<IPathService> _mockPathService;
+    private Mock<IXmpService> _mockXmpService;
     private AlbumService _albumService;
 
     [SetUp]
@@ -26,12 +27,13 @@ public class AlbumServiceTests {
         _mockSettingsService = new Mock<ISettingsService>();
         _mockPictureRepository = new Mock<IPictureRepository>();
         _mockPathService = new Mock<IPathService>();
+        _mockXmpService = new Mock<IXmpService>();
         
         _mockSettingsService.Setup(s => s.Current).Returns(new SettingsModel {
             LibraryPath = @"C:\Photos"
         });
 
-        _albumService = new AlbumService(_mockNodeService.Object, _mockFileSystem, _mockSettingsService.Object, _mockPictureRepository.Object, _mockPathService.Object);
+        _albumService = new AlbumService(_mockNodeService.Object, _mockFileSystem, _mockSettingsService.Object, _mockPictureRepository.Object, _mockPathService.Object, _mockXmpService.Object);
 
         // Configure mock NodeService to simulate the strategy's Prepare behavior
         _mockNodeService

--- a/Graph.Test/ImportPicturesCommandTests.cs
+++ b/Graph.Test/ImportPicturesCommandTests.cs
@@ -14,6 +14,8 @@ public class ImportPicturesCommandTests {
     private Mock<IAlbumService> _mockAlbumService;
     private Mock<INodeService> _mockNodeService;
     private Mock<IPictureAnalyzer> _mockPictureAnalyzer;
+    private Mock<IXmpService> _mockXmpService;
+    private Mock<IPathService> _mockPathService;
     private ImportPicturesCommand _command;
 
     [SetUp]
@@ -22,12 +24,16 @@ public class ImportPicturesCommandTests {
         _mockAlbumService = new Mock<IAlbumService>();
         _mockNodeService = new Mock<INodeService>();
         _mockPictureAnalyzer = new Mock<IPictureAnalyzer>();
+        _mockXmpService = new Mock<IXmpService>();
+        _mockPathService = new Mock<IPathService>();
 
         _command = new ImportPicturesCommand(
             _mockAlbumService.Object,
             _mockNodeService.Object,
             _mockFileSystem,
-            _mockPictureAnalyzer.Object);
+            _mockPictureAnalyzer.Object,
+            _mockXmpService.Object,
+            _mockPathService.Object);
     }
 
     [Test]

--- a/Graph.Test/XmpServiceTests.cs
+++ b/Graph.Test/XmpServiceTests.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Database.Domain.Entities;
+using Database.Infrastructure.Data;
+using Domain.Enums;
+using Graph.Domain.Interfaces;
+using Graph.Infrastructure.Services;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Graph.Test;
+
+[TestFixture]
+public class XmpServiceTests : IDisposable {
+    private MockFileSystem _mockFileSystem;
+    private Mock<IPathService> _mockPathService;
+    private ApplicationDbContext _context;
+    private SqliteConnection _connection;
+    private IServiceScopeFactory _scopeFactory;
+    private XmpService _xmpService;
+
+    [SetUp]
+    public void Setup() {
+        _mockFileSystem = new MockFileSystem();
+        _mockPathService = new Mock<IPathService>();
+
+        // Set up in-memory SQLite database
+        _connection = new SqliteConnection("Filename=:memory:");
+        _connection.Open();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        _context.Database.EnsureCreated();
+
+        // Register in DI to get a real ServiceScopeFactory
+        var services = new ServiceCollection();
+        services.AddSingleton(_context);
+        var provider = services.BuildServiceProvider();
+        _scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+        _xmpService = new XmpService(_mockFileSystem, _scopeFactory, _mockPathService.Object);
+    }
+
+    [TearDown]
+    public void TearDown() {
+        _context.Dispose();
+        _connection.Close();
+    }
+
+    public void Dispose() {
+        TearDown();
+    }
+
+    [Test]
+    public async Task LoadMetadataAsync_WhenFileDoesNotExist_ShouldSetDefaults() {
+        // Arrange
+        var picture = new Picture {
+            Name = "Pic1",
+            SubFolder = new SubFolder {
+                Raw = @"C:\RAWs\Pic1.NEF"
+            }
+        };
+
+        // Act
+        await _xmpService.LoadMetadataAsync(picture);
+
+        // Assert
+        Assert.Multiple(() => {
+            Assert.That(picture.Rating, Is.EqualTo(0));
+            Assert.That(picture.ColorLabel, Is.EqualTo(ColorLabel.None));
+            Assert.That(picture.CurationStatus, Is.EqualTo(CurationStatus.Unflagged));
+        });
+    }
+
+    [Test]
+    public async Task SaveAndLoad_ShouldPreserveValues() {
+        // Arrange
+        var rawPath = @"C:\RAWs\Pic1.NEF";
+        var xmpPath = @"C:\RAWs\Pic1.xmp";
+        _mockFileSystem.AddDirectory(@"C:\RAWs");
+
+        var picture = new Picture {
+            Name = "Pic1",
+            CapturedAt = new DateTime(2026, 6, 30, 12, 0, 0),
+            Rating = 4,
+            ColorLabel = ColorLabel.Red,
+            CurationStatus = CurationStatus.Flagged,
+            SubFolder = new SubFolder {
+                Raw = rawPath
+            }
+        };
+
+        // Act - Save
+        await _xmpService.SaveMetadataAsync(picture);
+
+        // Assert file exists
+        Assert.That(_mockFileSystem.File.Exists(xmpPath), Is.True);
+
+        // Create new picture to load into
+        var pictureToLoad = new Picture {
+            Name = "Pic1",
+            SubFolder = new SubFolder {
+                Raw = rawPath
+            }
+        };
+
+        // Act - Load
+        await _xmpService.LoadMetadataAsync(pictureToLoad);
+
+        // Assert loaded correctly
+        Assert.Multiple(() => {
+            Assert.That(pictureToLoad.Rating, Is.EqualTo(4));
+            Assert.That(pictureToLoad.ColorLabel, Is.EqualTo(ColorLabel.Red));
+            Assert.That(pictureToLoad.CurationStatus, Is.EqualTo(CurationStatus.Flagged));
+            Assert.That(pictureToLoad.CapturedAt, Is.EqualTo(picture.CapturedAt));
+        });
+    }
+
+    [Test]
+    public async Task SaveMetadataAsync_WhenXmpExists_ShouldPreserveOtherXmlElements() {
+        // Arrange
+        var rawPath = @"C:\RAWs\Pic1.NEF";
+        var xmpPath = @"C:\RAWs\Pic1.xmp";
+        _mockFileSystem.AddDirectory(@"C:\RAWs");
+
+        var initialXml = @"<x:xmpmeta xmlns:x=""adobe:ns:meta/"">
+  <rdf:RDF xmlns:rdf=""http://www.w3.org/1999/02/22-rdf-syntax-ns#"">
+    <rdf:Description rdf:about="""" xmlns:other=""http://other.com/"" other:CustomField=""custom_value"">
+    </rdf:Description>
+  </rdf:RDF>
+</x:xmpmeta>";
+
+        _mockFileSystem.AddFile(xmpPath, new MockFileData(initialXml));
+
+        var picture = new Picture {
+            Name = "Pic1",
+            Rating = 3,
+            SubFolder = new SubFolder {
+                Raw = rawPath
+            }
+        };
+
+        // Act
+        await _xmpService.SaveMetadataAsync(picture);
+
+        // Assert custom field is preserved
+        var savedXmlContent = _mockFileSystem.File.ReadAllText(xmpPath);
+        var doc = XDocument.Parse(savedXmlContent);
+        var desc = doc.Descendants().FirstOrDefault(el => el.Name.LocalName == "Description");
+        
+        Assert.That(desc, Is.Not.Null);
+        Assert.That(desc.Attribute(XNamespace.Get("http://other.com/") + "CustomField")?.Value, Is.EqualTo("custom_value"));
+        Assert.That(desc.Attribute(XNamespace.Get("http://ns.adobe.com/xap/1.0/") + "Rating")?.Value, Is.EqualTo("3"));
+    }
+
+    [Test]
+    public async Task CreateXmpForAlbumAsync_ShouldUseLegacyDatabaseData() {
+        // Arrange
+        var album = new Album { Id = 100, Name = "TestAlbum", Uuid = "test-uuid" };
+        _context.Nodes.Add(album);
+        await _context.SaveChangesAsync();
+
+        var pic1 = new Picture {
+            Id = 200,
+            Name = "Pic1",
+            ParentId = album.Id,
+            Type = NodeType.Picture,
+            CapturedAt = new DateTime(2026, 6, 30),
+            Extension = ".NEF"
+        };
+        _context.Nodes.Add(pic1);
+        await _context.SaveChangesAsync();
+
+        // Write directly to SQLite legacy columns since EF Core [NotMapped] ignores them now
+        var connection = _context.Database.GetDbConnection();
+        var originalState = connection.State;
+        if (originalState != System.Data.ConnectionState.Open) {
+            await connection.OpenAsync();
+        }
+        using (var command = connection.CreateCommand()) {
+            command.CommandText = @"
+                ALTER TABLE pictures ADD COLUMN CurationStatus TEXT;
+                ALTER TABLE pictures ADD COLUMN ColorLabel TEXT;
+                ALTER TABLE pictures ADD COLUMN Rating INTEGER;
+                
+                UPDATE pictures 
+                SET CurationStatus = 'Flagged', ColorLabel = 'Blue', Rating = 5 
+                WHERE Id = 200";
+            await command.ExecuteNonQueryAsync();
+        }
+        if (originalState != System.Data.ConnectionState.Open) {
+            await connection.CloseAsync();
+        }
+
+        var rawPath = @"C:\Library\test-uuid\RAWs\Pic1.NEF";
+        var xmpPath = @"C:\Library\test-uuid\RAWs\Pic1.xmp";
+        _mockFileSystem.AddDirectory(@"C:\Library\test-uuid\RAWs");
+
+        _mockPathService.Setup(s => s.PopulatePaths(It.IsAny<IEnumerable<Picture>>()))
+            .Callback<IEnumerable<Picture>>(pics => {
+                foreach (var pic in pics) {
+                    pic.SubFolder = new SubFolder {
+                        Raw = rawPath
+                    };
+                }
+            });
+
+        // Act
+        await _xmpService.CreateXmpForAlbumAsync(album.Id);
+
+        // Assert XMP file was created
+        Assert.That(_mockFileSystem.File.Exists(xmpPath), Is.True);
+
+        // Load metadata from created file
+        var testPic = new Picture {
+            Name = "Pic1",
+            SubFolder = new SubFolder {
+                Raw = rawPath
+            }
+        };
+        await _xmpService.LoadMetadataAsync(testPic);
+
+        Assert.Multiple(() => {
+            Assert.That(testPic.Rating, Is.EqualTo(5));
+            Assert.That(testPic.ColorLabel, Is.EqualTo(ColorLabel.Blue));
+            Assert.That(testPic.CurationStatus, Is.EqualTo(CurationStatus.Flagged));
+        });
+    }
+}

--- a/Graph.Test/XmpServiceTests.cs
+++ b/Graph.Test/XmpServiceTests.cs
@@ -235,4 +235,127 @@ public class XmpServiceTests : IDisposable {
             Assert.That(testPic.CurationStatus, Is.EqualTo(CurationStatus.Flagged));
         });
     }
+
+    [Test]
+    public async Task LoadMetadataAsync_WhenXmpDMPropertiesPresent_ShouldMapXmpDMCorrectly() {
+        // Arrange
+        var rawPath = @"C:\RAWs\PicDM.NEF";
+        var xmpPath = @"C:\RAWs\PicDM.xmp";
+        _mockFileSystem.AddDirectory(@"C:\RAWs");
+
+        var xmpContent = @"<?xpacket begin='﻿' id='W5M0MpCehiHzreSzNTczkc9d'?>
+<x:xmpmeta xmlns:x='adobe:ns:meta/'>
+ <rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'>
+  <rdf:Description rdf:about=''
+    xmlns:xmp='http://ns.adobe.com/xap/1.0/'
+    xmlns:xmpDM='http://ns.adobe.com/xmp/1.0/DynamicMedia/'
+    xmp:Rating='3'
+    xmpDM:pick='1'>
+  </rdf:Description>
+ </rdf:RDF>
+</x:xmpmeta>";
+        _mockFileSystem.AddFile(xmpPath, xmpContent);
+
+        var picture = new Picture {
+            Name = "PicDM",
+            SubFolder = new SubFolder {
+                Raw = rawPath
+            }
+        };
+
+        // Act
+        await _xmpService.LoadMetadataAsync(picture);
+
+        // Assert
+        Assert.Multiple(() => {
+            Assert.That(picture.Rating, Is.EqualTo(3));
+            Assert.That(picture.CurationStatus, Is.EqualTo(CurationStatus.Flagged));
+        });
+    }
+
+    [Test]
+    public async Task LoadMetadataAsync_CurationStates_ShouldMapCorrectly() {
+        var xmpDM = XNamespace.Get("http://ns.adobe.com/xmp/1.0/DynamicMedia/");
+        
+        // 1. Picked
+        var xmlPicked = $@"<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description rdf:about='' xmlns:xmpDM='{xmpDM.NamespaceName}' xmpDM:pick='1'/></rdf:RDF></x:xmpmeta>";
+        _mockFileSystem.AddFile(@"C:\RAWs\Picked.xmp", xmlPicked);
+        var picPicked = new Picture { SubFolder = new SubFolder { Raw = @"C:\RAWs\Picked.NEF" } };
+        await _xmpService.LoadMetadataAsync(picPicked);
+        Assert.That(picPicked.CurationStatus, Is.EqualTo(CurationStatus.Flagged));
+
+        // 2. Unflagged
+        var xmlUnflagged = $@"<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description rdf:about='' xmlns:xmpDM='{xmpDM.NamespaceName}' xmpDM:pick='0'/></rdf:RDF></x:xmpmeta>";
+        _mockFileSystem.AddFile(@"C:\RAWs\Unflagged.xmp", xmlUnflagged);
+        var picUnflagged = new Picture { SubFolder = new SubFolder { Raw = @"C:\RAWs\Unflagged.NEF" } };
+        await _xmpService.LoadMetadataAsync(picUnflagged);
+        Assert.That(picUnflagged.CurationStatus, Is.EqualTo(CurationStatus.Unflagged));
+
+        // 3. Rejected
+        var xmlRejected = $@"<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description rdf:about='' xmlns:xmpDM='{xmpDM.NamespaceName}' xmpDM:pick='-1'/></rdf:RDF></x:xmpmeta>";
+        _mockFileSystem.AddFile(@"C:\RAWs\Rejected.xmp", xmlRejected);
+        var picRejected = new Picture { SubFolder = new SubFolder { Raw = @"C:\RAWs\Rejected.NEF" } };
+        await _xmpService.LoadMetadataAsync(picRejected);
+        Assert.That(picRejected.CurationStatus, Is.EqualTo(CurationStatus.Rejected));
+    }
+
+    [Test]
+    public async Task LoadMetadataAsync_LegacyFallbackUrgency5_ShouldMapToPickedAndRewrite() {
+        var xmpPath = @"C:\RAWs\Legacy5.xmp";
+        var xml = @"<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description rdf:about='' xmlns:photoshop='http://ns.adobe.com/photoshop/1.0/' photoshop:Urgency='5'/></rdf:RDF></x:xmpmeta>";
+        _mockFileSystem.AddFile(xmpPath, xml);
+        var picture = new Picture { Name = "Legacy5", SubFolder = new SubFolder { Raw = @"C:\RAWs\Legacy5.NEF" } };
+        
+        await _xmpService.LoadMetadataAsync(picture);
+        
+        // CurationStatus should be Picked (Flagged)
+        Assert.That(picture.CurationStatus, Is.EqualTo(CurationStatus.Flagged));
+
+        // XMP file should have been rewritten
+        var rewrittenXml = _mockFileSystem.File.ReadAllText(xmpPath);
+        var doc = XDocument.Parse(rewrittenXml);
+        var desc = doc.Descendants().First(e => e.Name.LocalName == "Description");
+        
+        var xmpDM = XNamespace.Get("http://ns.adobe.com/xmp/1.0/DynamicMedia/");
+        Assert.That(desc.Attribute(xmpDM + "pick")?.Value, Is.EqualTo("1"));
+        Assert.That(desc.Attribute(xmpDM + "good")?.Value, Is.EqualTo("true"));
+        Assert.That(desc.Attribute(XNamespace.Get("http://ns.adobe.com/photoshop/1.0/") + "Urgency"), Is.Null);
+    }
+
+    [Test]
+    public async Task SaveMetadataAsync_ShouldCleanPhotoshopUrgencyAndMapXmpDMStates() {
+        var xmpDM = XNamespace.Get("http://ns.adobe.com/xmp/1.0/DynamicMedia/");
+        var photoshop = XNamespace.Get("http://ns.adobe.com/photoshop/1.0/");
+
+        // 1. Save Picked
+        var picPicked = new Picture { CurationStatus = CurationStatus.Flagged, SubFolder = new SubFolder { Raw = @"C:\RAWs\SavePicked.NEF" } };
+        var xmlPickedInitial = @"<x:xmpmeta xmlns:x='adobe:ns:meta/'><rdf:RDF xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'><rdf:Description rdf:about='' xmlns:photoshop='http://ns.adobe.com/photoshop/1.0/' photoshop:Urgency='5'/></rdf:RDF></x:xmpmeta>";
+        _mockFileSystem.AddFile(@"C:\RAWs\SavePicked.xmp", xmlPickedInitial);
+        await _xmpService.SaveMetadataAsync(picPicked);
+
+        var savedXml1 = _mockFileSystem.File.ReadAllText(@"C:\RAWs\SavePicked.xmp");
+        var doc1 = XDocument.Parse(savedXml1);
+        var desc1 = doc1.Descendants().First(e => e.Name.LocalName == "Description");
+        Assert.That(desc1.Attribute(xmpDM + "pick")?.Value, Is.EqualTo("1"));
+        Assert.That(desc1.Attribute(xmpDM + "good")?.Value, Is.EqualTo("true"));
+        Assert.That(desc1.Attribute(photoshop + "Urgency"), Is.Null);
+
+        // 2. Save Unflagged
+        var picUnflagged = new Picture { CurationStatus = CurationStatus.Unflagged, SubFolder = new SubFolder { Raw = @"C:\RAWs\SaveUnflagged.NEF" } };
+        await _xmpService.SaveMetadataAsync(picUnflagged);
+        var savedXml2 = _mockFileSystem.File.ReadAllText(@"C:\RAWs\SaveUnflagged.xmp");
+        var doc2 = XDocument.Parse(savedXml2);
+        var desc2 = doc2.Descendants().First(e => e.Name.LocalName == "Description");
+        Assert.That(desc2.Attribute(xmpDM + "pick")?.Value, Is.EqualTo("0"));
+        Assert.That(desc2.Attribute(xmpDM + "good"), Is.Null);
+
+        // 3. Save Rejected
+        var picRejected = new Picture { CurationStatus = CurationStatus.Rejected, SubFolder = new SubFolder { Raw = @"C:\RAWs\SaveRejected.NEF" } };
+        await _xmpService.SaveMetadataAsync(picRejected);
+        var savedXml3 = _mockFileSystem.File.ReadAllText(@"C:\RAWs\SaveRejected.xmp");
+        var doc3 = XDocument.Parse(savedXml3);
+        var desc3 = doc3.Descendants().First(e => e.Name.LocalName == "Description");
+        Assert.That(desc3.Attribute(xmpDM + "pick")?.Value, Is.EqualTo("-1"));
+        Assert.That(desc3.Attribute(xmpDM + "good")?.Value, Is.EqualTo("false"));
+    }
 }

--- a/Graph/Domain/Interfaces/IXmpService.cs
+++ b/Graph/Domain/Interfaces/IXmpService.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Database.Domain.Entities;
+
+namespace Graph.Domain.Interfaces;
+
+public interface IXmpService {
+    /// <summary>
+    ///     Loads metadata (Rating, ColorLabel, CurationStatus, CapturedAt) from the picture's XMP sidecar file.
+    ///     If the file does not exist, it sets default values.
+    /// </summary>
+    Task LoadMetadataAsync(Picture picture);
+
+    /// <summary>
+    ///     Saves metadata (Rating, ColorLabel, CurationStatus, CapturedAt) from the picture to the XMP sidecar file.
+    ///     If the file already exists, it loads it and updates the attributes to preserve other metadata tags.
+    /// </summary>
+    Task SaveMetadataAsync(Picture picture);
+
+    /// <summary>
+    ///     Generates missing XMP sidecar files for an entire album using the legacy database columns.
+    /// </summary>
+    Task CreateXmpForAlbumAsync(int albumId);
+}

--- a/Graph/Infrastructure/Commands/ImportPicturesCommand.cs
+++ b/Graph/Infrastructure/Commands/ImportPicturesCommand.cs
@@ -17,16 +17,22 @@ public class ImportPicturesCommand : IImportPicturesCommand {
     private readonly IFileSystem _fileSystem;
     private readonly INodeService _nodeService;
     private readonly IPictureAnalyzer _pictureAnalyzer;
+    private readonly IXmpService _xmpService;
+    private readonly IPathService _pathService;
 
     public ImportPicturesCommand(
         IAlbumService albumService,
         INodeService nodeService,
         IFileSystem fileSystem,
-        IPictureAnalyzer pictureAnalyzer) {
+        IPictureAnalyzer pictureAnalyzer,
+        IXmpService xmpService,
+        IPathService pathService) {
         _albumService = albumService;
         _nodeService = nodeService;
         _fileSystem = fileSystem;
         _pictureAnalyzer = pictureAnalyzer;
+        _xmpService = xmpService;
+        _pathService = pathService;
     }
 
     public async Task<Album> ExecuteAsync(int? parentId, string albumName, string libraryPath, string sourcePath,
@@ -149,6 +155,10 @@ public class ImportPicturesCommand : IImportPicturesCommand {
             };
 
             await _nodeService.CreateNodeAsync(pictureNode);
+
+            pictureNode.Parent = album;
+            _pathService.PopulatePaths(pictureNode);
+            await _xmpService.SaveMetadataAsync(pictureNode);
 
             album.Children ??= new List<Node>();
             if (!album.Children.Contains(pictureNode)) {

--- a/Graph/Infrastructure/Services/AlbumService.cs
+++ b/Graph/Infrastructure/Services/AlbumService.cs
@@ -12,7 +12,8 @@ public class AlbumService(
     IFileSystem fileSystem,
     ISettingsService settingsService,
     IPictureRepository pictureRepository,
-    IPathService pathService) : IAlbumService {
+    IPathService pathService,
+    IXmpService xmpService) : IAlbumService {
     public async Task<Album> CreateAsync(int? parentId, string albumName, string path) {
         var album = new Album {
             Name = albumName,
@@ -83,17 +84,23 @@ public class AlbumService(
         }
 
         var pictures = await pictureRepository.FindByHierarchyIdAsync(album.Id);
+        foreach (var picture in pictures) {
+            picture.Parent = album;
+        }
+        pathService.PopulatePaths(pictures);
 
         foreach (var picture in pictures) {
-            bool isPickedOnDisk = pickedFileNames.Contains(picture.Name);
-            bool isFlaggedInDb = picture.CurationStatus == CurationStatus.Flagged;
+            await xmpService.LoadMetadataAsync(picture);
 
-            if (isPickedOnDisk && !isFlaggedInDb) {
+            bool isPickedOnDisk = pickedFileNames.Contains(picture.Name);
+            bool isFlagged = picture.CurationStatus == CurationStatus.Flagged;
+
+            if (isPickedOnDisk && !isFlagged) {
                 picture.CurationStatus = CurationStatus.Flagged;
-                await pictureRepository.UpdateAsync(picture);
-            } else if (!isPickedOnDisk && isFlaggedInDb) {
+                await xmpService.SaveMetadataAsync(picture);
+            } else if (!isPickedOnDisk && isFlagged) {
                 picture.CurationStatus = CurationStatus.Unflagged;
-                await pictureRepository.UpdateAsync(picture);
+                await xmpService.SaveMetadataAsync(picture);
             }
         }
     }

--- a/Graph/Infrastructure/Services/XmpService.cs
+++ b/Graph/Infrastructure/Services/XmpService.cs
@@ -38,6 +38,7 @@ public class XmpService(
         }
 
         var xmpPath = fileSystem.Path.ChangeExtension(picture.SubFolder.Raw, ".xmp");
+
         if (!fileSystem.File.Exists(xmpPath)) {
             picture.Rating = 0;
             picture.ColorLabel = ColorLabel.None;
@@ -56,6 +57,9 @@ public class XmpService(
             var doc = XDocument.Parse(content);
             var desc = doc.Descendants(rdf + "Description").FirstOrDefault();
             if (desc == null) {
+                picture.Rating = 0;
+                picture.ColorLabel = ColorLabel.None;
+                picture.CurationStatus = CurationStatus.Unflagged;
                 return;
             }
 
@@ -85,18 +89,34 @@ public class XmpService(
             }
             picture.ColorLabel = ParseColorLabel(labelStr);
 
-            // 3. Curation Status (photoshop:Urgency)
-            var urgencyVal = 5; // default Neutral
-            var urgencyAttr = desc.Attribute(photoshop + "Urgency");
-            if (urgencyAttr != null) {
-                int.TryParse(urgencyAttr.Value, out urgencyVal);
+            // 3. Curation Status (xmpDM:pick with photoshop:Urgency="5" legacy fallback)
+            var xmpDM = XNamespace.Get("http://ns.adobe.com/xmp/1.0/DynamicMedia/");
+            var pickAttrVal = desc.Attribute(xmpDM + "pick")?.Value ?? desc.Element(xmpDM + "pick")?.Value;
+            bool shouldRewrite = false;
+
+            if (pickAttrVal != null) {
+                if (int.TryParse(pickAttrVal, out var pickVal)) {
+                    picture.CurationStatus = pickVal switch {
+                        1 => CurationStatus.Flagged,
+                        -1 => CurationStatus.Rejected,
+                        _ => CurationStatus.Unflagged
+                    };
+                } else {
+                    picture.CurationStatus = CurationStatus.Unflagged;
+                }
             } else {
-                var urgencyElem = desc.Element(photoshop + "Urgency");
-                if (urgencyElem != null) {
-                    int.TryParse(urgencyElem.Value, out urgencyVal);
+                var urgencyAttrVal = desc.Attribute(photoshop + "Urgency")?.Value ?? desc.Element(photoshop + "Urgency")?.Value;
+                if (urgencyAttrVal == "5") {
+                    picture.CurationStatus = CurationStatus.Flagged;
+                    shouldRewrite = true;
+                } else {
+                    picture.CurationStatus = CurationStatus.Unflagged;
                 }
             }
-            picture.CurationStatus = ParseCurationStatus(urgencyVal);
+
+            if (shouldRewrite) {
+                await SaveMetadataAsync(picture);
+            }
 
             // 4. CreateDate -> CapturedAt
             var createDateStr = "";
@@ -160,7 +180,23 @@ public class XmpService(
             desc.SetAttributeValue(xmp + "CreatorTool", "Picturebot");
             desc.SetAttributeValue(xmp + "Rating", picture.Rating.ToString());
             desc.SetAttributeValue(xmp + "Label", picture.ColorLabel == ColorLabel.None ? "" : picture.ColorLabel.ToString());
-            desc.SetAttributeValue(photoshop + "Urgency", GetUrgencyValue(picture.CurationStatus).ToString());
+            // Safely remove photoshop:Urgency to keep file clean
+            desc.Attribute(photoshop + "Urgency")?.Remove();
+            desc.Element(photoshop + "Urgency")?.Remove();
+
+            // Write xmpDM:pick and xmpDM:good for Lightroom compatibility
+            var xmpDM = XNamespace.Get("http://ns.adobe.com/xmp/1.0/DynamicMedia/");
+            if (picture.CurationStatus == CurationStatus.Flagged) {
+                desc.SetAttributeValue(xmpDM + "pick", "1");
+                desc.SetAttributeValue(xmpDM + "good", "true");
+            } else if (picture.CurationStatus == CurationStatus.Rejected) {
+                desc.SetAttributeValue(xmpDM + "pick", "-1");
+                desc.SetAttributeValue(xmpDM + "good", "false");
+            } else {
+                desc.SetAttributeValue(xmpDM + "pick", "0");
+                desc.Attribute(xmpDM + "good")?.Remove();
+                desc.Element(xmpDM + "good")?.Remove();
+            }
 
             var nowStr = DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss");
             desc.SetAttributeValue(xmp + "ModifyDate", nowStr);
@@ -299,6 +335,52 @@ public class XmpService(
         if (desc.Attribute(XNamespace.Xmlns + "xmp") == null) desc.Add(new XAttribute(XNamespace.Xmlns + "xmp", xmp.NamespaceName));
         if (desc.Attribute(XNamespace.Xmlns + "dc") == null) desc.Add(new XAttribute(XNamespace.Xmlns + "dc", dc.NamespaceName));
         if (desc.Attribute(XNamespace.Xmlns + "photoshop") == null) desc.Add(new XAttribute(XNamespace.Xmlns + "photoshop", photoshop.NamespaceName));
+        var xmpDM = XNamespace.Get("http://ns.adobe.com/xmp/1.0/DynamicMedia/");
+        if (desc.Attribute(XNamespace.Xmlns + "xmpDM") == null) desc.Add(new XAttribute(XNamespace.Xmlns + "xmpDM", xmpDM.NamespaceName));
+    }
+
+    private async Task<(CurationStatus? status, ColorLabel? label, int? rating)> GetLegacyDataAsync(int pictureId) {
+        try {
+            using var scope = scopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var connection = context.Database.GetDbConnection();
+            var originalState = connection.State;
+            if (originalState != System.Data.ConnectionState.Open) {
+                await connection.OpenAsync();
+            }
+            try {
+                using var command = connection.CreateCommand();
+                command.CommandText = "SELECT CurationStatus, ColorLabel, Rating FROM pictures WHERE Id = @id";
+                var param = command.CreateParameter();
+                param.ParameterName = "@id";
+                param.Value = pictureId;
+                command.Parameters.Add(param);
+
+                using var reader = await command.ExecuteReaderAsync();
+                if (await reader.ReadAsync()) {
+                    var statusStr = reader.IsDBNull(0) ? null : reader.GetString(0);
+                    var labelStr = reader.IsDBNull(1) ? null : reader.GetString(1);
+                    var ratingVal = reader.IsDBNull(2) ? (int?)null : reader.GetInt32(2);
+
+                    CurationStatus? status = null;
+                    if (statusStr != null && Enum.TryParse<CurationStatus>(statusStr, out var parsedStatus)) {
+                        status = parsedStatus;
+                    }
+                    ColorLabel? label = null;
+                    if (labelStr != null && Enum.TryParse<ColorLabel>(labelStr, out var parsedLabel)) {
+                        label = parsedLabel;
+                    }
+                    return (status, label, ratingVal);
+                }
+            } finally {
+                if (originalState != System.Data.ConnectionState.Open) {
+                    await connection.CloseAsync();
+                }
+            }
+        } catch (Exception ex) {
+            Log.Warning(ex, "Failed to load legacy fallback metadata for picture {Id}", pictureId);
+        }
+        return (null, null, null);
     }
 
     private void UpdateTitleElement(XElement desc, string title) {

--- a/Graph/Infrastructure/Services/XmpService.cs
+++ b/Graph/Infrastructure/Services/XmpService.cs
@@ -1,0 +1,327 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using System.IO.Abstractions;
+using Database.Domain.Entities;
+using Database.Infrastructure.Data;
+using Domain.Enums;
+using Graph.Domain.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Serilog;
+
+namespace Graph.Infrastructure.Services;
+
+public class XmpService(
+    IFileSystem fileSystem,
+    IServiceScopeFactory scopeFactory,
+    IPathService pathService) : IXmpService {
+
+    private static readonly XNamespace rdf = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+    private static readonly XNamespace xmp = "http://ns.adobe.com/xap/1.0/";
+    private static readonly XNamespace dc = "http://purl.org/dc/elements/1.1/";
+    private static readonly XNamespace photoshop = "http://ns.adobe.com/photoshop/1.0/";
+
+    public async Task LoadMetadataAsync(Picture picture) {
+        if (picture.SubFolder == null) {
+            pathService.PopulatePaths(picture);
+        }
+
+        if (picture.SubFolder == null || string.IsNullOrEmpty(picture.SubFolder.Raw)) {
+            picture.Rating = 0;
+            picture.ColorLabel = ColorLabel.None;
+            picture.CurationStatus = CurationStatus.Unflagged;
+            return;
+        }
+
+        var xmpPath = fileSystem.Path.ChangeExtension(picture.SubFolder.Raw, ".xmp");
+        if (!fileSystem.File.Exists(xmpPath)) {
+            picture.Rating = 0;
+            picture.ColorLabel = ColorLabel.None;
+            picture.CurationStatus = CurationStatus.Unflagged;
+            return;
+        }
+
+        try {
+            // Read file with sharing permissions since other editors might lock/open it
+            string content;
+            using (var stream = fileSystem.FileStream.New(xmpPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var reader = new StreamReader(stream)) {
+                content = await reader.ReadToEndAsync();
+            }
+
+            var doc = XDocument.Parse(content);
+            var desc = doc.Descendants(rdf + "Description").FirstOrDefault();
+            if (desc == null) {
+                return;
+            }
+
+            // 1. Rating
+            var ratingVal = 0;
+            var ratingAttr = desc.Attribute(xmp + "Rating");
+            if (ratingAttr != null) {
+                int.TryParse(ratingAttr.Value, out ratingVal);
+            } else {
+                var ratingElem = desc.Element(xmp + "Rating");
+                if (ratingElem != null) {
+                    int.TryParse(ratingElem.Value, out ratingVal);
+                }
+            }
+            picture.Rating = Math.Clamp(ratingVal, 0, 5);
+
+            // 2. Color Label
+            var labelStr = "";
+            var labelAttr = desc.Attribute(xmp + "Label");
+            if (labelAttr != null) {
+                labelStr = labelAttr.Value;
+            } else {
+                var labelElem = desc.Element(xmp + "Label");
+                if (labelElem != null) {
+                    labelStr = labelElem.Value;
+                }
+            }
+            picture.ColorLabel = ParseColorLabel(labelStr);
+
+            // 3. Curation Status (photoshop:Urgency)
+            var urgencyVal = 5; // default Neutral
+            var urgencyAttr = desc.Attribute(photoshop + "Urgency");
+            if (urgencyAttr != null) {
+                int.TryParse(urgencyAttr.Value, out urgencyVal);
+            } else {
+                var urgencyElem = desc.Element(photoshop + "Urgency");
+                if (urgencyElem != null) {
+                    int.TryParse(urgencyElem.Value, out urgencyVal);
+                }
+            }
+            picture.CurationStatus = ParseCurationStatus(urgencyVal);
+
+            // 4. CreateDate -> CapturedAt
+            var createDateStr = "";
+            var createDateAttr = desc.Attribute(xmp + "CreateDate");
+            if (createDateAttr != null) {
+                createDateStr = createDateAttr.Value;
+            } else {
+                var createDateElem = desc.Element(xmp + "CreateDate");
+                if (createDateElem != null) {
+                    createDateStr = createDateElem.Value;
+                }
+            }
+            if (DateTime.TryParse(createDateStr, out var createDate)) {
+                picture.CapturedAt = createDate;
+            }
+        } catch (Exception ex) {
+            Log.Error(ex, "Failed to load XMP metadata for picture {Name} from {Path}", picture.Name, xmpPath);
+        }
+    }
+
+    public async Task SaveMetadataAsync(Picture picture) {
+        if (picture.SubFolder == null) {
+            pathService.PopulatePaths(picture);
+        }
+
+        if (picture.SubFolder == null || string.IsNullOrEmpty(picture.SubFolder.Raw)) {
+            return;
+        }
+
+        var xmpPath = fileSystem.Path.ChangeExtension(picture.SubFolder.Raw, ".xmp");
+
+        try {
+            XDocument doc;
+            XElement desc;
+
+            if (fileSystem.File.Exists(xmpPath)) {
+                string content;
+                using (var stream = fileSystem.FileStream.New(xmpPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                using (var reader = new StreamReader(stream)) {
+                    content = await reader.ReadToEndAsync();
+                }
+                
+                doc = XDocument.Parse(content);
+                desc = doc.Descendants(rdf + "Description").FirstOrDefault();
+                if (desc == null) {
+                    desc = new XElement(rdf + "Description", new XAttribute(rdf + "about", ""));
+                    var rdfElement = doc.Descendants(rdf + "RDF").FirstOrDefault();
+                    if (rdfElement != null) {
+                        rdfElement.Add(desc);
+                    } else {
+                        doc = CreateNewXmpDocument(out desc);
+                    }
+                }
+            } else {
+                doc = CreateNewXmpDocument(out desc);
+            }
+
+            EnsureNamespaceAttributes(desc);
+
+            // Set/update attributes
+            desc.SetAttributeValue(xmp + "CreatorTool", "Picturebot");
+            desc.SetAttributeValue(xmp + "Rating", picture.Rating.ToString());
+            desc.SetAttributeValue(xmp + "Label", picture.ColorLabel == ColorLabel.None ? "" : picture.ColorLabel.ToString());
+            desc.SetAttributeValue(photoshop + "Urgency", GetUrgencyValue(picture.CurationStatus).ToString());
+
+            var nowStr = DateTime.Now.ToString("yyyy-MM-ddTHH:mm:ss");
+            desc.SetAttributeValue(xmp + "ModifyDate", nowStr);
+            desc.SetAttributeValue(xmp + "MetadataDate", nowStr);
+            if (desc.Attribute(xmp + "CreateDate") == null) {
+                desc.SetAttributeValue(xmp + "CreateDate", picture.CapturedAt.ToString("yyyy-MM-ddTHH:mm:ss"));
+            }
+
+            UpdateTitleElement(desc, picture.Name);
+
+            var parentDir = fileSystem.Path.GetDirectoryName(xmpPath);
+            if (!string.IsNullOrEmpty(parentDir) && !fileSystem.Directory.Exists(parentDir)) {
+                fileSystem.Directory.CreateDirectory(parentDir);
+            }
+
+            // Write XML to file with retries in case other programs are locking it temporarily
+            const int maxRetries = 5;
+            for (int i = 0; i < maxRetries; i++) {
+                try {
+                    using var stream = fileSystem.FileStream.New(xmpPath, FileMode.Create, FileAccess.Write, FileShare.None);
+                    using var writer = new StreamWriter(stream);
+                    await writer.WriteAsync(doc.ToString());
+                    break;
+                } catch (IOException) when (i < maxRetries - 1) {
+                    await Task.Delay(100);
+                }
+            }
+        } catch (Exception ex) {
+            Log.Error(ex, "Failed to save XMP metadata for picture {Name} to {Path}", picture.Name, xmpPath);
+        }
+    }
+
+    public async Task CreateXmpForAlbumAsync(int albumId) {
+        using var scope = scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var album = await context.Nodes.OfType<Album>().FirstOrDefaultAsync(a => a.Id == albumId);
+        if (album == null) return;
+
+        var pictures = await context.Nodes
+            .OfType<Picture>()
+            .Where(p => p.ParentId == albumId)
+            .ToListAsync();
+
+        foreach (var picture in pictures) {
+            picture.Parent = album;
+        }
+
+        pathService.PopulatePaths(pictures);
+
+        var connection = context.Database.GetDbConnection();
+        var originalState = connection.State;
+        if (originalState != System.Data.ConnectionState.Open) {
+            await connection.OpenAsync();
+        }
+
+        try {
+            using var command = connection.CreateCommand();
+            command.CommandText = "SELECT p.Id, p.CurationStatus, p.ColorLabel, p.Rating FROM pictures p INNER JOIN nodes n ON p.Id = n.Id WHERE n.ParentId = @albumId";
+            
+            var param = command.CreateParameter();
+            param.ParameterName = "@albumId";
+            param.Value = albumId;
+            command.Parameters.Add(param);
+
+            var legacyData = new Dictionary<int, (CurationStatus status, ColorLabel label, int rating)>();
+            using (var reader = await command.ExecuteReaderAsync()) {
+                while (await reader.ReadAsync()) {
+                    var id = reader.GetInt32(0);
+                    var statusStr = reader.IsDBNull(1) ? "Unflagged" : reader.GetString(1);
+                    var labelStr = reader.IsDBNull(2) ? "None" : reader.GetString(2);
+                    var rating = reader.IsDBNull(3) ? 0 : reader.GetInt32(3);
+
+                    Enum.TryParse<CurationStatus>(statusStr, out var status);
+                    Enum.TryParse<ColorLabel>(labelStr, out var label);
+
+                    legacyData[id] = (status, label, rating);
+                }
+            }
+
+            foreach (var picture in pictures) {
+                if (legacyData.TryGetValue(picture.Id, out var legacy)) {
+                    picture.CurationStatus = legacy.status;
+                    picture.ColorLabel = legacy.label;
+                    picture.Rating = legacy.rating;
+
+                    await SaveMetadataAsync(picture);
+                }
+            }
+        } finally {
+            if (originalState != System.Data.ConnectionState.Open) {
+                await connection.CloseAsync();
+            }
+        }
+    }
+
+    private ColorLabel ParseColorLabel(string label) {
+        if (string.IsNullOrEmpty(label)) return ColorLabel.None;
+        if (Enum.TryParse<ColorLabel>(label, true, out var result)) {
+            return result;
+        }
+        return ColorLabel.None;
+    }
+
+    private CurationStatus ParseCurationStatus(int urgency) {
+        return urgency switch {
+            1 => CurationStatus.Flagged,
+            8 => CurationStatus.Rejected,
+            _ => CurationStatus.Unflagged
+        };
+    }
+
+    private int GetUrgencyValue(CurationStatus status) {
+        return status switch {
+            CurationStatus.Flagged => 1,
+            CurationStatus.Rejected => 8,
+            _ => 5
+        };
+    }
+
+    private XDocument CreateNewXmpDocument(out XElement desc) {
+        desc = new XElement(rdf + "Description",
+            new XAttribute(rdf + "about", "")
+        );
+
+        var rdfElem = new XElement(rdf + "RDF", desc);
+        var xmpMeta = new XElement(XNamespace.Get("adobe:ns:meta/") + "xmpmeta",
+            new XAttribute(XNamespace.Xmlns + "x", "adobe:ns:meta/"),
+            rdfElem
+        );
+
+        return new XDocument(new XDeclaration("1.0", "utf-8", "yes"), xmpMeta);
+    }
+
+    private void EnsureNamespaceAttributes(XElement desc) {
+        if (desc.Attribute(XNamespace.Xmlns + "xmp") == null) desc.Add(new XAttribute(XNamespace.Xmlns + "xmp", xmp.NamespaceName));
+        if (desc.Attribute(XNamespace.Xmlns + "dc") == null) desc.Add(new XAttribute(XNamespace.Xmlns + "dc", dc.NamespaceName));
+        if (desc.Attribute(XNamespace.Xmlns + "photoshop") == null) desc.Add(new XAttribute(XNamespace.Xmlns + "photoshop", photoshop.NamespaceName));
+    }
+
+    private void UpdateTitleElement(XElement desc, string title) {
+        var titleElem = desc.Element(dc + "title");
+        if (titleElem == null) {
+            titleElem = new XElement(dc + "title");
+            desc.Add(titleElem);
+        }
+
+        var altElem = titleElem.Element(rdf + "Alt");
+        if (altElem == null) {
+            altElem = new XElement(rdf + "Alt");
+            titleElem.Add(altElem);
+        }
+
+        var defaultLi = altElem.Elements(rdf + "li")
+            .FirstOrDefault(el => el.Attribute(XNamespace.Xml + "lang")?.Value == "x-default");
+
+        if (defaultLi == null) {
+            defaultLi = new XElement(rdf + "li", new XAttribute(XNamespace.Xml + "lang", "x-default"));
+            altElem.Add(defaultLi);
+        }
+
+        defaultLi.Value = title;
+    }
+}

--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.7.1</Version>
+        <Version>1.8.1</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.8.1</Version>
+        <Version>1.8.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/Program.cs
+++ b/Picturebot/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
@@ -73,6 +73,7 @@ internal sealed class Program {
             services.AddSingleton<INavigationService, NavigationService>();
             services.AddSingleton<IFileSystem, FileSystem>();
             services.AddScoped<IPathService, PathService>();
+            services.AddScoped<IXmpService, XmpService>();
             services.AddScoped<ICopyService, CopyService>();
             services.AddSingleton<IPictureAnalyzer, PictureAnalyzerService>();
             services.AddSingleton<IPictureProcessor, PictureProcessorService>();

--- a/Picturebot/Services/SettingsService.cs
+++ b/Picturebot/Services/SettingsService.cs
@@ -9,14 +9,16 @@ using Domain.Interfaces;
 using Domain.Models;
 using SukiUI;
 
+using Microsoft.Extensions.DependencyInjection;
+
 namespace Picturebot.Services;
 
 public class SettingsService : ISettingsService {
-    private readonly ISettingsRepository _repository;
+    private readonly IServiceScopeFactory _scopeFactory;
     private SettingsModel _current = new();
 
-    public SettingsService(ISettingsRepository repository) {
-        _repository = repository;
+    public SettingsService(IServiceScopeFactory scopeFactory) {
+        _scopeFactory = scopeFactory;
     }
 
     public SettingsModel Current {
@@ -34,13 +36,17 @@ public class SettingsService : ISettingsService {
     public event PropertyChangedEventHandler? PropertyChanged;
 
     public async Task InitializeAsync() {
-        var settings = await _repository.LoadAsync();
+        using var scope = _scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<ISettingsRepository>();
+        var settings = await repository.LoadAsync();
         Current = settings;
         ApplyTheme(settings.ThemeMode);
     }
 
     public async Task UpdateAsync(SettingsModel settings) {
-        await _repository.UpdateAsync(settings);
+        using var scope = _scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<ISettingsRepository>();
+        await repository.UpdateAsync(settings);
         Current = settings;
         ApplyTheme(settings.ThemeMode);
     }

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -731,6 +731,7 @@ public partial class GalleryViewModel : ViewModelBase,
         AlbumItems.Clear();
 
         foreach (var picVm in _allPictures) {
+            picVm.PropertyChanged -= OnPictureItemPropertyChanged;
             picVm.Dispose();
         }
 
@@ -751,6 +752,7 @@ public partial class GalleryViewModel : ViewModelBase,
 
                 foreach (var pic in pics) {
                     var picVm = new PictureItemViewModel(pic);
+                    picVm.PropertyChanged += OnPictureItemPropertyChanged;
                     _allPictures.Add(picVm);
                     _ = picVm.LoadThumbnailAsync(250);
                 }
@@ -780,6 +782,14 @@ public partial class GalleryViewModel : ViewModelBase,
         }
 
         UpdateBreadcrumbs(currentNode);
+    }
+
+    private void OnPictureItemPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e) {
+        if (e.PropertyName == nameof(PictureItemViewModel.CurationStatus) ||
+            e.PropertyName == nameof(PictureItemViewModel.Rating) ||
+            e.PropertyName == nameof(PictureItemViewModel.ColorLabel)) {
+            ApplyFilters();
+        }
     }
 
     private void ToggleStatusFilter(CurationStatus status, bool isActive) {

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -44,6 +44,7 @@ public partial class GalleryViewModel : ViewModelBase,
     private readonly INodeService _nodeService;
     private readonly IPathService _pathService;
     private readonly ISettingsService _settingsService;
+    private readonly IXmpService _xmpService;
     private readonly HashSet<string> _pendingThumbnailRefreshes = new();
     private readonly DispatcherTimer _refreshTimer;
     private readonly List<PictureItemViewModel> _allPictures = new();
@@ -122,7 +123,8 @@ public partial class GalleryViewModel : ViewModelBase,
     public GalleryViewModel(INodeService nodeService, IPathService pathService,
         IPictureGroupingService groupingService, INavigationService navigationService,
         ISettingsService settingsService, ICurationQueue curationQueue,
-        IAlbumService albumService, IFolderService folderService, ICopyService copyService) {
+        IAlbumService albumService, IFolderService folderService, ICopyService copyService,
+        IXmpService xmpService) {
         _nodeService = nodeService;
         _pathService = pathService;
         _groupingService = groupingService;
@@ -132,6 +134,7 @@ public partial class GalleryViewModel : ViewModelBase,
         _albumService = albumService;
         _folderService = folderService;
         _copyService = copyService;
+        _xmpService = xmpService;
 
         _refreshTimer = new DispatcherTimer(
             TimeSpan.FromMilliseconds(500),
@@ -239,8 +242,12 @@ public partial class GalleryViewModel : ViewModelBase,
         }
     }
 
-    public void Receive(NodeSelectedMessage message) {
-        UpdateGallery(message.Value);
+    public async void Receive(NodeSelectedMessage message) {
+        if (message.Value is Album album) {
+            await LoadAlbumAsync(album);
+        } else {
+            UpdateGallery(message.Value);
+        }
     }
 
     [RelayCommand]
@@ -508,6 +515,18 @@ public partial class GalleryViewModel : ViewModelBase,
 
             // Re-fetch children to get the updated entities and refresh the view
             var children = await _nodeService.FindChildrenAsync(album.Id);
+            var pics = children.OfType<Picture>().ToList();
+            foreach (var pic in pics) {
+                pic.Parent = album;
+            }
+            _pathService.PopulatePaths(pics);
+
+            await Task.Run(async () => {
+                foreach (var pic in pics) {
+                    await _xmpService.LoadMetadataAsync(pic);
+                }
+            });
+
             UpdateGalleryItems(album, children);
             
             MainWindow.ToastManager.CreateToast()
@@ -689,8 +708,13 @@ public partial class GalleryViewModel : ViewModelBase,
 
     private void UpdateGallery(Node? node) {
         if (node == null) {
+            TearDownXmpWatcher();
             _ = LoadInitialItemsAsync();
             return;
+        }
+
+        if (node is not Album) {
+            TearDownXmpWatcher();
         }
 
         UpdateGalleryItems(node, node.Children?.ToList());
@@ -955,6 +979,180 @@ public partial class GalleryViewModel : ViewModelBase,
         Log.Information("Processing completed for current album {Id}, refreshing gallery.", message.Value);
         Dispatcher.UIThread.Post(() => {
             _ = RefreshGalleryGrouping();
+        });
+    }
+
+    [RelayCommand(CanExecute = nameof(IsShowingAlbum))]
+    private async Task CreateXmpFiles() {
+        if (_currentNode is not Album album) {
+            return;
+        }
+
+        try {
+            MainWindow.ToastManager.CreateToast()
+                .WithTitle("Generating XMP Files")
+                .WithContent($"Generating XMP sidecar files for album '{album.Name}'...")
+                .Dismiss().After(TimeSpan.FromSeconds(2))
+                .Queue();
+
+            await _xmpService.CreateXmpForAlbumAsync(album.Id);
+
+            // Re-load the current items to reflect the newly created XMP files
+            await LoadAlbumAsync(album);
+
+            MainWindow.ToastManager.CreateToast()
+                .WithTitle("Success")
+                .WithContent($"Successfully created XMP sidecars using legacy data for album '{album.Name}'.")
+                .Dismiss().After(TimeSpan.FromSeconds(3))
+                .Queue();
+        } catch (Exception ex) {
+            Log.Error(ex, "Failed to create XMP files for album {AlbumName}", album.Name);
+            
+            MainWindow.ToastManager.CreateToast()
+                .WithTitle("Error")
+                .WithContent($"Failed to generate XMP files: {ex.Message}")
+                .Dismiss().After(TimeSpan.FromSeconds(4))
+                .Queue();
+        }
+    }
+
+    private FileSystemWatcher? _xmpWatcher;
+
+    private async Task LoadAlbumAsync(Album album) {
+        SetupXmpWatcher(album);
+
+        // Find children
+        var children = await _nodeService.FindChildrenAsync(album.Id);
+        var pics = children.OfType<Picture>().ToList();
+
+        // Populate paths
+        foreach (var pic in pics) {
+            pic.Parent = album;
+        }
+        _pathService.PopulatePaths(pics);
+
+        // Load XMP metadata in background thread
+        await Task.Run(async () => {
+            foreach (var pic in pics) {
+                await _xmpService.LoadMetadataAsync(pic);
+            }
+        });
+
+        // Update the gallery items on UI thread
+        UpdateGalleryItems(album, children);
+    }
+
+    private void SetupXmpWatcher(Album album) {
+        TearDownXmpWatcher();
+
+        if (string.IsNullOrEmpty(_settingsService.Current.LibraryPath) || string.IsNullOrEmpty(album.Uuid)) {
+            return;
+        }
+
+        var rawsPath = Path.Combine(_settingsService.Current.LibraryPath, album.Uuid, "RAWs");
+        if (!Directory.Exists(rawsPath)) {
+            return;
+        }
+
+        try {
+            _xmpWatcher = new FileSystemWatcher(rawsPath, "*.xmp") {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.CreationTime,
+                EnableRaisingEvents = true
+            };
+
+            _xmpWatcher.Changed += OnXmpFileChanged;
+            _xmpWatcher.Created += OnXmpFileChanged;
+            _xmpWatcher.Deleted += OnXmpFileChanged;
+            _xmpWatcher.Renamed += OnXmpFileRenamed;
+        } catch (Exception ex) {
+            Log.Error(ex, "Failed to start FileSystemWatcher for album {Uuid} at {Path}", album.Uuid, rawsPath);
+        }
+    }
+
+    private void TearDownXmpWatcher() {
+        if (_xmpWatcher != null) {
+            _xmpWatcher.EnableRaisingEvents = false;
+            _xmpWatcher.Changed -= OnXmpFileChanged;
+            _xmpWatcher.Created -= OnXmpFileChanged;
+            _xmpWatcher.Deleted -= OnXmpFileChanged;
+            _xmpWatcher.Renamed -= OnXmpFileRenamed;
+            _xmpWatcher.Dispose();
+            _xmpWatcher = null;
+        }
+    }
+
+    private void OnXmpFileChanged(object sender, FileSystemEventArgs e) {
+        var fileName = Path.GetFileNameWithoutExtension(e.Name);
+        if (string.IsNullOrEmpty(fileName)) return;
+
+        Dispatcher.UIThread.Post(async () => {
+            var picVm = _allPictures.FirstOrDefault(p => p.Name.Equals(fileName, StringComparison.OrdinalIgnoreCase));
+            if (picVm == null) return;
+
+            if (e.ChangeType == WatcherChangeTypes.Deleted) {
+                picVm.Picture.CurationStatus = CurationStatus.Unflagged;
+                picVm.Picture.ColorLabel = ColorLabel.None;
+                picVm.Picture.Rating = 0;
+
+                picVm.CurationStatus = CurationStatus.Unflagged;
+                picVm.ColorLabel = ColorLabel.None;
+                picVm.Rating = 0;
+            } else {
+                var originalCapturedAt = picVm.Picture.CapturedAt;
+
+                await _xmpService.LoadMetadataAsync(picVm.Picture);
+
+                picVm.CurationStatus = picVm.Picture.CurationStatus;
+                picVm.ColorLabel = picVm.Picture.ColorLabel;
+                picVm.Rating = picVm.Picture.Rating;
+
+                if (picVm.Picture.CapturedAt != originalCapturedAt) {
+                    await _nodeService.UpdateNodeAsync(picVm.Picture);
+                    _ = RefreshGalleryGrouping();
+                }
+            }
+
+            ApplyFilters();
+        });
+    }
+
+    private void OnXmpFileRenamed(object sender, RenamedEventArgs e) {
+        var oldName = Path.GetFileNameWithoutExtension(e.OldName);
+        var newName = Path.GetFileNameWithoutExtension(e.Name);
+
+        Dispatcher.UIThread.Post(async () => {
+            if (!string.IsNullOrEmpty(oldName)) {
+                var oldPicVm = _allPictures.FirstOrDefault(p => p.Name.Equals(oldName, StringComparison.OrdinalIgnoreCase));
+                if (oldPicVm != null) {
+                    oldPicVm.Picture.CurationStatus = CurationStatus.Unflagged;
+                    oldPicVm.Picture.ColorLabel = ColorLabel.None;
+                    oldPicVm.Picture.Rating = 0;
+
+                    oldPicVm.CurationStatus = CurationStatus.Unflagged;
+                    oldPicVm.ColorLabel = ColorLabel.None;
+                    oldPicVm.Rating = 0;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(newName)) {
+                var newPicVm = _allPictures.FirstOrDefault(p => p.Name.Equals(newName, StringComparison.OrdinalIgnoreCase));
+                if (newPicVm != null) {
+                    var originalCapturedAt = newPicVm.Picture.CapturedAt;
+
+                    await _xmpService.LoadMetadataAsync(newPicVm.Picture);
+
+                    newPicVm.CurationStatus = newPicVm.Picture.CurationStatus;
+                    newPicVm.ColorLabel = newPicVm.Picture.ColorLabel;
+                    newPicVm.Rating = newPicVm.Picture.Rating;
+
+                    if (newPicVm.Picture.CapturedAt != originalCapturedAt) {
+                        await _nodeService.UpdateNodeAsync(newPicVm.Picture);
+                        _ = RefreshGalleryGrouping();
+                    }
+                }
+            }
+
+            ApplyFilters();
         });
     }
 

--- a/Picturebot/Views/GalleryView.axaml
+++ b/Picturebot/Views/GalleryView.axaml
@@ -345,6 +345,12 @@
                                         <icons:MaterialIcon Kind="FolderSyncOutline" Width="18" Height="18" />
                                     </MenuItem.Icon>
                                 </MenuItem>
+                                <MenuItem Header="Create XMP files"
+                                          Command="{Binding CreateXmpFilesCommand}">
+                                    <MenuItem.Icon>
+                                        <icons:MaterialIcon Kind="FileExportOutline" Width="18" Height="18" />
+                                    </MenuItem.Icon>
+                                </MenuItem>
                             </MenuFlyout>
                         </Button.Flyout>
                     </Button>

--- a/Synchronize.Test/CurationQueueTests.cs
+++ b/Synchronize.Test/CurationQueueTests.cs
@@ -11,6 +11,7 @@ namespace Synchronize.Test;
 public class CurationQueueTests {
     private Mock<IPickedService> _mockPickedService;
     private Mock<INodeService> _mockNodeService;
+    private Mock<IXmpService> _mockXmpService;
     private Mock<IServiceScopeFactory> _mockScopeFactory;
     private Mock<IServiceScope> _mockScope;
     private Mock<IServiceProvider> _mockServiceProvider;
@@ -20,6 +21,7 @@ public class CurationQueueTests {
     public void Setup() {
         _mockPickedService = new Mock<IPickedService>();
         _mockNodeService = new Mock<INodeService>();
+        _mockXmpService = new Mock<IXmpService>();
         _mockScopeFactory = new Mock<IServiceScopeFactory>();
         _mockScope = new Mock<IServiceScope>();
         _mockServiceProvider = new Mock<IServiceProvider>();
@@ -28,6 +30,7 @@ public class CurationQueueTests {
         _mockScope.Setup(s => s.ServiceProvider).Returns(_mockServiceProvider.Object);
         _mockServiceProvider.Setup(s => s.GetService(typeof(INodeService))).Returns(_mockNodeService.Object);
         _mockServiceProvider.Setup(s => s.GetService(typeof(IPickedService))).Returns(_mockPickedService.Object);
+        _mockServiceProvider.Setup(s => s.GetService(typeof(IXmpService))).Returns(_mockXmpService.Object);
 
         _curationQueue = new CurationQueue(_mockScopeFactory.Object);
     }

--- a/SynchronizeWorker/CurationQueue.cs
+++ b/SynchronizeWorker/CurationQueue.cs
@@ -65,6 +65,10 @@ public class CurationQueue : ICurationQueue, IHostedService, IDisposable {
                         // 1. Adds the curated picture 'preview' to the database 
                         await nodeService.UpdateNodeAsync(picture);
 
+                        // 1.5. Save metadata to XMP file
+                        var xmpService = scope.ServiceProvider.GetRequiredService<IXmpService>();
+                        await xmpService.SaveMetadataAsync(picture);
+
                         // 2. copy to the 'Picked' folder
                         await pickedService.SyncToPickedAsync(picture);
                         


### PR DESCRIPTION
### Summary
This pull request introduces XMP metadata support across various services, commands, and UI components while refining the handling of legacy `pictures` table structures. Key updates include:

- **XMP Metadata Handling:**
  - Added `IXmpService` interface and `XmpService` implementation for picture metadata management.
  - Enhanced `XmpService` with features like metadata curation status mapping, legacy fallback, real-time filtering, and XMP rewriting.
  - Implemented album-level XMP generation and real-time file change handling.
  - Created comprehensive tests for loading, saving, and generating XMP files.

- **Legacy Table Improvements:**
  - Made `pictures` table columns nullable and updated the migration process to ensure compatibility with existing data and schema changes.
  - Disabled transactions for legacy table migration for smoother upgrades.

- **Additional Improvements:**
  - Scoped repository usage in `SettingsService`.
  - Adjusted app version rollback to 1.8.0 for alignment with recent updates.

### Checklist
- [ ] Merge conflicts resolved
- [ ] Unit and integration tests added/updated
- [ ] Documentation updated if applicable

### Additional Notes
These changes ensure smoother metadata management and maintain compatibility with legacy systems, enhancing overall application performance and reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added XMP sidecar support for pictures, including reading, saving, and generating files for albums.
  * Added a gallery action to create XMP files for the current album.
  * Gallery metadata now stays in sync when XMP files change.

* **Bug Fixes**
  * Improved handling of picture updates to avoid unintended relationship changes.
  * Updated metadata handling so curation, color label, and rating values are stored consistently.
  * Background curation now also saves updated metadata alongside file organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->