### PR TITLE
Sync highlights & picked folders

### DIFF
--- a/Graph.Test/AlbumServiceTests.cs
+++ b/Graph.Test/AlbumServiceTests.cs
@@ -129,4 +129,71 @@ public class AlbumServiceTests {
             _mockNodeService.Verify(s => s.DeleteNodeAsync(album), Times.Once);
         });
     }
+
+    [Test]
+    public async Task SyncHighlightsAsync_ShouldCopyBlueLabeledPreviewsAndCleanupOthers() {
+        // Arrange
+        var albumUuid = Guid.NewGuid().ToString();
+        var album = new Album { Id = 10, Uuid = albumUuid, Name = "Test Album" };
+        var libraryPath = @"C:\Photos";
+        var highlightsPath = Path.Combine(libraryPath, albumUuid, "Highlights");
+        var jpgsPath = Path.Combine(libraryPath, albumUuid, "JPGs");
+
+        _mockFileSystem.AddDirectory(jpgsPath);
+        _mockFileSystem.AddDirectory(highlightsPath);
+
+        // Pre-existing file in Highlights that should be removed because it's not a blue highlight picture
+        _mockFileSystem.AddFile(Path.Combine(highlightsPath, "stray.jpg"), new MockFileData("stray"));
+        // Pre-existing file in Highlights that belongs to a blue picture (should be overwritten/kept)
+        _mockFileSystem.AddFile(Path.Combine(highlightsPath, "blue1.jpg"), new MockFileData("old_blue"));
+        // Pre-existing file in Highlights that belongs to a non-blue picture (should be deleted)
+        _mockFileSystem.AddFile(Path.Combine(highlightsPath, "red1.jpg"), new MockFileData("old_red"));
+
+        // Source JPG files
+        _mockFileSystem.AddFile(Path.Combine(jpgsPath, "blue1.jpg"), new MockFileData("blue1_data"));
+        _mockFileSystem.AddFile(Path.Combine(jpgsPath, "blue2.jpg"), new MockFileData("blue2_data"));
+        _mockFileSystem.AddFile(Path.Combine(jpgsPath, "red1.jpg"), new MockFileData("red1_data"));
+
+        var pics = new List<Picture> {
+            new() { Id = 1, Name = "blue1", ColorLabel = ColorLabel.Blue, Parent = album },
+            new() { Id = 2, Name = "blue2", ColorLabel = ColorLabel.Blue, Parent = album },
+            new() { Id = 3, Name = "red1", ColorLabel = ColorLabel.Red, Parent = album }
+        };
+
+        _mockPictureRepository.Setup(r => r.FindByHierarchyIdAsync(album.Id)).ReturnsAsync(pics);
+        _mockPathService.Setup(p => p.GetAlbumHighlightsPath(album)).Returns(highlightsPath);
+        _mockPathService.Setup(p => p.PopulatePaths(It.IsAny<IEnumerable<Picture>>()))
+            .Callback<IEnumerable<Picture>>(pictures => {
+                foreach (var p in pictures) {
+                    p.SubFolder = new SubFolder {
+                        Preview = Path.Combine(jpgsPath, p.Name + ".jpg")
+                    };
+                }
+            });
+        _mockXmpService.Setup(x => x.LoadMetadataAsync(It.IsAny<Picture>())).Returns(Task.CompletedTask);
+
+        // Act
+        await _albumService.SyncHighlightsAsync(album);
+
+        // Assert
+        Assert.Multiple(() => {
+            // Verify blue1.jpg exists and was overwritten with new content
+            var blue1Path = Path.Combine(highlightsPath, "blue1.jpg");
+            Assert.That(_mockFileSystem.File.Exists(blue1Path), Is.True);
+            Assert.That(_mockFileSystem.File.ReadAllText(blue1Path), Is.EqualTo("blue1_data"));
+
+            // Verify blue2.jpg was copied
+            var blue2Path = Path.Combine(highlightsPath, "blue2.jpg");
+            Assert.That(_mockFileSystem.File.Exists(blue2Path), Is.True);
+            Assert.That(_mockFileSystem.File.ReadAllText(blue2Path), Is.EqualTo("blue2_data"));
+
+            // Verify red1.jpg was deleted/not copied
+            var red1Path = Path.Combine(highlightsPath, "red1.jpg");
+            Assert.That(_mockFileSystem.File.Exists(red1Path), Is.False);
+
+            // Verify stray.jpg was deleted
+            var strayPath = Path.Combine(highlightsPath, "stray.jpg");
+            Assert.That(_mockFileSystem.File.Exists(strayPath), Is.False);
+        });
+    }
 }

--- a/Graph.Test/PickedServiceTests.cs
+++ b/Graph.Test/PickedServiceTests.cs
@@ -87,4 +87,62 @@ public class PickedServiceTests {
         // Assert
         _mockPathService.Verify(s => s.PopulatePaths(picture), Times.Once);
     }
+
+    [Test]
+    public async Task SyncToHighlightAsync_WhenBlue_ShouldCopyPreviewToHighlights() {
+        // Arrange
+        var album = new Album { Uuid = "Album1" };
+        var previewPath = @"C:\Library\Album1\JPGs\Pic1.jpg";
+        var highlightsDir = @"C:\Library\Album1\Highlights";
+        var highlightPath = @"C:\Library\Album1\Highlights\Pic1.jpg";
+        var previewContent = "fake image content";
+        
+        _mockFileSystem.AddDirectory(@"C:\Library\Album1\JPGs");
+        _mockFileSystem.AddFile(previewPath, new MockFileData(previewContent));
+
+        var picture = new Picture {
+            Name = "Pic1",
+            ColorLabel = ColorLabel.Blue,
+            Parent = album,
+            SubFolder = new SubFolder {
+                Preview = previewPath
+            }
+        };
+
+        _mockPathService.Setup(p => p.GetAlbumHighlightsPath(album)).Returns(highlightsDir);
+
+        // Act
+        await _pickedService.SyncToHighlightAsync(picture);
+
+        // Assert
+        Assert.That(_mockFileSystem.File.Exists(highlightPath), Is.True);
+        Assert.That(_mockFileSystem.GetFile(highlightPath).TextContents, Is.EqualTo(previewContent));
+    }
+
+    [Test]
+    public async Task SyncToHighlightAsync_WhenNotBlue_ShouldDeleteHighlightsFile() {
+        // Arrange
+        var album = new Album { Uuid = "Album1" };
+        var highlightsDir = @"C:\Library\Album1\Highlights";
+        var highlightPath = @"C:\Library\Album1\Highlights\Pic1.jpg";
+        _mockFileSystem.AddDirectory(highlightsDir);
+        _mockFileSystem.AddFile(highlightPath, new MockFileData("existing content"));
+
+        var picture = new Picture {
+            Name = "Pic1",
+            ColorLabel = ColorLabel.Red,
+            Parent = album,
+            SubFolder = new SubFolder {
+                Preview = @"C:\Library\Album1\JPGs\Pic1.jpg"
+            }
+        };
+
+        _mockPathService.Setup(p => p.GetAlbumHighlightsPath(album)).Returns(highlightsDir);
+
+        // Act
+        await _pickedService.SyncToHighlightAsync(picture);
+
+        // Assert
+        Assert.That(_mockFileSystem.File.Exists(highlightPath), Is.False);
+    }
 }

--- a/Graph/Domain/Interfaces/IAlbumService.cs
+++ b/Graph/Domain/Interfaces/IAlbumService.cs
@@ -23,4 +23,11 @@ public interface IAlbumService {
     /// <param name="album">The album to synchronize.</param>
     /// <returns>A Task representing the asynchronous operation.</returns>
     Task SyncPickedStatusAsync(Album album);
+
+    /// <summary>
+    ///     Synchronizes the pictures within the album having the blue color label to the physical 'Highlights' directory.
+    /// </summary>
+    /// <param name="album">The album to synchronize.</param>
+    /// <returns>A Task representing the asynchronous operation.</returns>
+    Task SyncHighlightsAsync(Album album);
 }

--- a/Graph/Domain/Interfaces/IPathService.cs
+++ b/Graph/Domain/Interfaces/IPathService.cs
@@ -6,4 +6,5 @@ public interface IPathService {
     void PopulatePaths(Picture picture);
     void PopulatePaths(IEnumerable<Picture> pictures);
     string? GetAlbumPickedPath(Album album);
+    string? GetAlbumHighlightsPath(Album album);
 }

--- a/Graph/Domain/Interfaces/IPickedService.cs
+++ b/Graph/Domain/Interfaces/IPickedService.cs
@@ -4,4 +4,5 @@ namespace Graph.Domain.Interfaces;
 
 public interface IPickedService {
     Task SyncToPickedAsync(Picture picture);
+    Task SyncToHighlightAsync(Picture picture);
 }

--- a/Graph/Infrastructure/Services/AlbumService.cs
+++ b/Graph/Infrastructure/Services/AlbumService.cs
@@ -104,4 +104,59 @@ public class AlbumService(
             }
         }
     }
+
+    public async Task SyncHighlightsAsync(Album album) {
+        var highlightsPath = pathService.GetAlbumHighlightsPath(album);
+        if (string.IsNullOrEmpty(highlightsPath)) {
+            return;
+        }
+
+        var pictures = await pictureRepository.FindByHierarchyIdAsync(album.Id);
+        foreach (var picture in pictures) {
+            picture.Parent = album;
+        }
+        pathService.PopulatePaths(pictures);
+
+        var bluePictureNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var picture in pictures) {
+            await xmpService.LoadMetadataAsync(picture);
+            if (picture.ColorLabel == ColorLabel.Blue) {
+                bluePictureNames.Add(picture.Name);
+            }
+        }
+
+        // Ensure directory exists if we have highlights to copy
+        if (bluePictureNames.Count > 0 && !fileSystem.Directory.Exists(highlightsPath)) {
+            fileSystem.Directory.CreateDirectory(highlightsPath);
+        }
+
+        // Copy/overwrite blue pictures
+        foreach (var picture in pictures) {
+            if (picture.ColorLabel == ColorLabel.Blue) {
+                var previewPath = picture.SubFolder?.Preview;
+                if (!string.IsNullOrEmpty(previewPath) && fileSystem.File.Exists(previewPath)) {
+                    var targetPath = fileSystem.Path.Combine(highlightsPath, picture.Name + ".jpg");
+
+                    var directory = fileSystem.Path.GetDirectoryName(targetPath);
+                    if (directory != null && !fileSystem.Directory.Exists(directory)) {
+                        fileSystem.Directory.CreateDirectory(directory);
+                    }
+
+                    await Task.Run(() => fileSystem.File.Copy(previewPath, targetPath, true));
+                }
+            }
+        }
+
+        // Clean up files in Highlights that are no longer blue highlight pictures
+        if (fileSystem.Directory.Exists(highlightsPath)) {
+            var existingFiles = fileSystem.Directory.GetFiles(highlightsPath);
+            foreach (var file in existingFiles) {
+                var fileNameWithoutExt = fileSystem.Path.GetFileNameWithoutExtension(file);
+                if (!bluePictureNames.Contains(fileNameWithoutExt)) {
+                    await Task.Run(() => fileSystem.File.Delete(file));
+                }
+            }
+        }
+    }
 }

--- a/Graph/Infrastructure/Services/PathService.cs
+++ b/Graph/Infrastructure/Services/PathService.cs
@@ -36,4 +36,12 @@ public class PathService(ISettingsService settingsService, IFileSystem fileSyste
         var albumPath = fileSystem.Path.Combine(settingsService.Current.LibraryPath, album.Uuid);
         return fileSystem.Path.Combine(albumPath, "Picked");
     }
+
+    public string? GetAlbumHighlightsPath(Album album) {
+        if (string.IsNullOrEmpty(album.Uuid)) return null;
+        if (string.IsNullOrEmpty(settingsService.Current.LibraryPath)) return null;
+
+        var albumPath = fileSystem.Path.Combine(settingsService.Current.LibraryPath, album.Uuid);
+        return fileSystem.Path.Combine(albumPath, "Highlights");
+    }
 }

--- a/Graph/Infrastructure/Services/PickedService.cs
+++ b/Graph/Infrastructure/Services/PickedService.cs
@@ -35,4 +35,35 @@ public class PickedService(IFileSystem fileSystem, IPathService pathService) : I
             }
         }
     }
+
+    public async Task SyncToHighlightAsync(Picture picture) {
+        if (picture.Parent is not Album album) return;
+
+        var highlightsPath = pathService.GetAlbumHighlightsPath(album);
+        if (string.IsNullOrEmpty(highlightsPath)) return;
+
+        if (picture.SubFolder == null) {
+            pathService.PopulatePaths(picture);
+        }
+
+        if (picture.SubFolder == null) return;
+
+        var previewPath = picture.SubFolder.Preview;
+        var highlightFile = fileSystem.Path.Combine(highlightsPath, picture.Name + ".jpg");
+
+        if (picture.ColorLabel == ColorLabel.Blue) {
+            if (fileSystem.File.Exists(previewPath)) {
+                var directory = fileSystem.Path.GetDirectoryName(highlightFile);
+                if (directory != null && !fileSystem.Directory.Exists(directory)) {
+                    fileSystem.Directory.CreateDirectory(directory);
+                }
+
+                await Task.Run(() => fileSystem.File.Copy(previewPath, highlightFile, true));
+            }
+        } else {
+            if (fileSystem.File.Exists(highlightFile)) {
+                await Task.Run(() => fileSystem.File.Delete(highlightFile));
+            }
+        }
+    }
 }

--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.8.8</Version>
+        <Version>1.8.9</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -45,6 +45,7 @@ public partial class GalleryViewModel : ViewModelBase,
     private readonly IPathService _pathService;
     private readonly ISettingsService _settingsService;
     private readonly IXmpService _xmpService;
+    private readonly IPickedService _pickedService;
     private readonly HashSet<string> _pendingThumbnailRefreshes = new();
     private readonly DispatcherTimer _refreshTimer;
     private readonly List<PictureItemViewModel> _allPictures = new();
@@ -127,7 +128,7 @@ public partial class GalleryViewModel : ViewModelBase,
         IPictureGroupingService groupingService, INavigationService navigationService,
         ISettingsService settingsService, ICurationQueue curationQueue,
         IAlbumService albumService, IFolderService folderService, ICopyService copyService,
-        IXmpService xmpService) {
+        IXmpService xmpService, IPickedService pickedService) {
         _nodeService = nodeService;
         _pathService = pathService;
         _groupingService = groupingService;
@@ -138,6 +139,7 @@ public partial class GalleryViewModel : ViewModelBase,
         _folderService = folderService;
         _copyService = copyService;
         _xmpService = xmpService;
+        _pickedService = pickedService;
 
         _refreshTimer = new DispatcherTimer(
             TimeSpan.FromMilliseconds(500),
@@ -1127,6 +1129,16 @@ public partial class GalleryViewModel : ViewModelBase,
             // Load XMP metadata in parallel first
             await Task.WhenAll(firstBatchPics.Select(pic => _xmpService.LoadMetadataAsync(pic)));
 
+            // Sync picked files if they are missing
+            foreach (var pic in firstBatchPics) {
+                if (pic.CurationStatus == CurationStatus.Flagged) {
+                    var pickedPath = pic.SubFolder?.Picked;
+                    if (!string.IsNullOrEmpty(pickedPath) && !System.IO.File.Exists(pickedPath)) {
+                        await _pickedService.SyncToPickedAsync(pic);
+                    }
+                }
+            }
+
             // Create ViewModels
             var initialPicsList = new List<PictureItemViewModel>();
             foreach (var pic in firstBatchPics) {
@@ -1235,6 +1247,16 @@ public partial class GalleryViewModel : ViewModelBase,
                 await Parallel.ForEachAsync(chunk, new ParallelOptions { MaxDegreeOfParallelism = 16 }, async (pic, token) => {
                     await _xmpService.LoadMetadataAsync(pic);
                 });
+
+                // Sync picked files if they are missing
+                foreach (var pic in chunk) {
+                    if (pic.CurationStatus == CurationStatus.Flagged) {
+                        var pickedPath = pic.SubFolder?.Picked;
+                        if (!string.IsNullOrEmpty(pickedPath) && !System.IO.File.Exists(pickedPath)) {
+                            await _pickedService.SyncToPickedAsync(pic);
+                        }
+                    }
+                }
 
                 // Create ViewModels
                 var chunkVms = new List<PictureItemViewModel>();

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -558,6 +558,28 @@ public partial class GalleryViewModel : ViewModelBase,
         }
     }
 
+    [RelayCommand(CanExecute = nameof(CanExecuteSyncPicked))]
+    private async Task SynchronizeHighlightsAsync() {
+        if (_currentNode is not Album album) return;
+
+        try {
+            await _albumService.SyncHighlightsAsync(album);
+
+            MainWindow.ToastManager.CreateToast()
+                .WithTitle("Sync Complete")
+                .WithContent($"Successfully synchronized highlights for '{album.Name}'.")
+                .Dismiss().After(TimeSpan.FromSeconds(3))
+                .Queue();
+        } catch (Exception ex) {
+            Log.Error(ex, "Failed to sync highlights for album {AlbumId}", album.Id);
+            MainWindow.ToastManager.CreateToast()
+                .WithTitle("Sync Error")
+                .WithContent("Failed to synchronize highlights.")
+                .Dismiss().ByClicking()
+                .Queue();
+        }
+    }
+
     private bool CanExecuteSyncPicked() => CanPlayCarousel && CanExecuteShortcuts();
 
     [RelayCommand(CanExecute = nameof(CanExecutePlayCarousel))]

--- a/Picturebot/ViewModels/GalleryViewModel.cs
+++ b/Picturebot/ViewModels/GalleryViewModel.cs
@@ -1129,12 +1129,28 @@ public partial class GalleryViewModel : ViewModelBase,
             // Load XMP metadata in parallel first
             await Task.WhenAll(firstBatchPics.Select(pic => _xmpService.LoadMetadataAsync(pic)));
 
-            // Sync picked files if they are missing
+            // Sync picked and highlight files if they are missing
             foreach (var pic in firstBatchPics) {
                 if (pic.CurationStatus == CurationStatus.Flagged) {
                     var pickedPath = pic.SubFolder?.Picked;
                     if (!string.IsNullOrEmpty(pickedPath) && !System.IO.File.Exists(pickedPath)) {
                         await _pickedService.SyncToPickedAsync(pic);
+                    }
+                }
+                if (pic.ColorLabel == ColorLabel.Blue) {
+                    var highlightsPath = _pathService.GetAlbumHighlightsPath(album);
+                    if (!string.IsNullOrEmpty(highlightsPath)) {
+                        var highlightFile = System.IO.Path.Combine(highlightsPath, pic.Name + ".jpg");
+                        if (!System.IO.File.Exists(highlightFile)) {
+                            var previewPath = pic.SubFolder?.Preview;
+                            if (!string.IsNullOrEmpty(previewPath) && System.IO.File.Exists(previewPath)) {
+                                var directory = System.IO.Path.GetDirectoryName(highlightFile);
+                                if (directory != null && !System.IO.Directory.Exists(directory)) {
+                                    System.IO.Directory.CreateDirectory(directory);
+                                }
+                                await Task.Run(() => System.IO.File.Copy(previewPath, highlightFile, true));
+                            }
+                        }
                     }
                 }
             }
@@ -1248,12 +1264,28 @@ public partial class GalleryViewModel : ViewModelBase,
                     await _xmpService.LoadMetadataAsync(pic);
                 });
 
-                // Sync picked files if they are missing
+                // Sync picked and highlight files if they are missing
                 foreach (var pic in chunk) {
                     if (pic.CurationStatus == CurationStatus.Flagged) {
                         var pickedPath = pic.SubFolder?.Picked;
                         if (!string.IsNullOrEmpty(pickedPath) && !System.IO.File.Exists(pickedPath)) {
                             await _pickedService.SyncToPickedAsync(pic);
+                        }
+                    }
+                    if (pic.ColorLabel == ColorLabel.Blue) {
+                        var highlightsPath = _pathService.GetAlbumHighlightsPath(album);
+                        if (!string.IsNullOrEmpty(highlightsPath)) {
+                            var highlightFile = System.IO.Path.Combine(highlightsPath, pic.Name + ".jpg");
+                            if (!System.IO.File.Exists(highlightFile)) {
+                                var previewPath = pic.SubFolder?.Preview;
+                                if (!string.IsNullOrEmpty(previewPath) && System.IO.File.Exists(previewPath)) {
+                                    var directory = System.IO.Path.GetDirectoryName(highlightFile);
+                                    if (directory != null && !System.IO.Directory.Exists(directory)) {
+                                        System.IO.Directory.CreateDirectory(directory);
+                                    }
+                                    await Task.Run(() => System.IO.File.Copy(previewPath, highlightFile, true));
+                                }
+                            }
                         }
                     }
                 }

--- a/Picturebot/Views/GalleryView.axaml
+++ b/Picturebot/Views/GalleryView.axaml
@@ -346,6 +346,12 @@
                                         <icons:MaterialIcon Kind="FolderSyncOutline" Width="18" Height="18" />
                                     </MenuItem.Icon>
                                 </MenuItem>
+                                <MenuItem Header="Synchronize Highlights"
+                                          Command="{Binding SynchronizeHighlightsCommand}">
+                                    <MenuItem.Icon>
+                                        <icons:MaterialIcon Kind="StarOutline" Width="18" Height="18" />
+                                    </MenuItem.Icon>
+                                </MenuItem>
                                 <MenuItem Header="Create XMP files"
                                           Command="{Binding CreateXmpFilesCommand}">
                                     <MenuItem.Icon>

--- a/SynchronizeWorker/CurationQueue.cs
+++ b/SynchronizeWorker/CurationQueue.cs
@@ -71,6 +71,9 @@ public class CurationQueue : ICurationQueue, IHostedService, IDisposable {
 
                         // 2. copy to the 'Picked' folder
                         await pickedService.SyncToPickedAsync(picture);
+
+                        // 2.5. copy to the 'Highlights' folder
+                        await pickedService.SyncToHighlightAsync(picture);
                         
                         Log.Information("Successfully synchronized curation for {Name}", picture.Name);
                         _processedInBatch++;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added album actions to synchronize Highlights from blue-labeled pictures.
  * Highlights are automatically created, updated, or removed to match current labels.
  * Gallery loading repairs missing Picked and Highlights files when previews are available.
  * Curation synchronization now copies processed pictures to Highlights.
* **Bug Fixes**
  * Prevented outdated, stray, and non-blue highlight files from remaining.
* **Tests**
  * Added coverage for copying, overwriting, and cleaning up highlight previews.
* **Release**
  * Updated Picturebot to version 1.8.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->