### PR TITLE
feat(curation): enable bulk actions for keywords, tags, and statuses

### DIFF
--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.9.2</Version>
+        <Version>1.9.3</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/DetailsInspectorViewModel.cs
+++ b/Picturebot/ViewModels/DetailsInspectorViewModel.cs
@@ -150,6 +150,9 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
             foreach (var pic in message.Value) {
                 SelectedPictures.Add(pic);
             }
+            if (SelectedPicture == null || !SelectedPictures.Contains(SelectedPicture)) {
+                SelectedPicture = SelectedPictures.FirstOrDefault();
+            }
             UpdateActiveKeywords();
             UpdateQuickTagStates();
             OnPropertyChanged(nameof(ActiveMode));
@@ -419,7 +422,12 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
             }
         }
         if (!paths.Any()) {
-            paths.Add(tag.Name);
+            var pathByName = FindHierarchicalPathForTagInSettings(tag.Name);
+            if (!string.IsNullOrEmpty(pathByName)) {
+                paths.Add(pathByName);
+            } else {
+                paths.Add(tag.Name);
+            }
         }
         return paths;
     }
@@ -489,50 +497,60 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
 
     [RelayCommand]
     private async Task SetCurationStatus(CurationStatus status) {
-        var pictureVm = SelectedPicture;
-        if (pictureVm == null) {
+        var targetVms = SelectedPictures.Any() ? SelectedPictures.ToList() : (SelectedPicture != null ? new List<PictureItemViewModel> { SelectedPicture } : new List<PictureItemViewModel>());
+        if (!targetVms.Any()) {
             return;
         }
 
-        try {
-            pictureVm.CurationStatus = status;
-            _curationQueue.Enqueue(pictureVm.Picture);
-            await Task.CompletedTask;
-        } catch (Exception ex) {
-            Log.Error(ex, "Failed to update curation status for {Name}", pictureVm.Name);
+        foreach (var pictureVm in targetVms) {
+            try {
+                pictureVm.CurationStatus = status;
+                _curationQueue.Enqueue(pictureVm.Picture);
+            } catch (Exception ex) {
+                Log.Error(ex, "Failed to update curation status for {Name}", pictureVm.Name);
+            }
         }
+        await Task.CompletedTask;
     }
 
     [RelayCommand]
     private async Task SetColorLabel(ColorLabel label) {
-        var pictureVm = SelectedPicture;
-        if (pictureVm == null) {
+        var targetVms = SelectedPictures.Any() ? SelectedPictures.ToList() : (SelectedPicture != null ? new List<PictureItemViewModel> { SelectedPicture } : new List<PictureItemViewModel>());
+        if (!targetVms.Any()) {
             return;
         }
 
-        try {
-            pictureVm.ColorLabel = label;
-            _curationQueue.Enqueue(pictureVm.Picture);
-            await Task.CompletedTask;
-        } catch (Exception ex) {
-            Log.Error(ex, "Failed to update color label for {Name}", pictureVm.Name);
+        foreach (var pictureVm in targetVms) {
+            try {
+                pictureVm.ColorLabel = label;
+                _curationQueue.Enqueue(pictureVm.Picture);
+            } catch (Exception ex) {
+                Log.Error(ex, "Failed to update color label for {Name}", pictureVm.Name);
+            }
         }
+        await Task.CompletedTask;
     }
 
     [RelayCommand]
     private async Task SetRating(string ratingStr) {
-        var pictureVm = SelectedPicture;
-        if (pictureVm == null || !int.TryParse(ratingStr, out var rating)) {
+        if (!int.TryParse(ratingStr, out var rating)) {
             return;
         }
 
-        try {
-            pictureVm.Rating = rating;
-            _curationQueue.Enqueue(pictureVm.Picture);
-            await Task.CompletedTask;
-        } catch (Exception ex) {
-            Log.Error(ex, "Failed to update rating for {Name}", pictureVm.Name);
+        var targetVms = SelectedPictures.Any() ? SelectedPictures.ToList() : (SelectedPicture != null ? new List<PictureItemViewModel> { SelectedPicture } : new List<PictureItemViewModel>());
+        if (!targetVms.Any()) {
+            return;
         }
+
+        foreach (var pictureVm in targetVms) {
+            try {
+                pictureVm.Rating = rating;
+                _curationQueue.Enqueue(pictureVm.Picture);
+            } catch (Exception ex) {
+                Log.Error(ex, "Failed to update rating for {Name}", pictureVm.Name);
+            }
+        }
+        await Task.CompletedTask;
     }
 
     [RelayCommand]
@@ -590,6 +608,8 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
             targetVms.Add(SelectedPicture);
         }
 
+        if (!targetVms.Any()) return;
+
         string? resolvedHierarchicalPath = null;
         List<string> flatSegmentsToAdd = new();
 
@@ -617,23 +637,26 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
             }
         }
 
-        bool changed = false;
+        bool anyChanged = false;
         foreach (var picVm in targetVms) {
+            bool picChanged = false;
+
             if (!string.IsNullOrEmpty(resolvedHierarchicalPath)) {
                 if (!picVm.Keywords.Contains(resolvedHierarchicalPath, StringComparer.OrdinalIgnoreCase)) {
                     picVm.AddKeyword(resolvedHierarchicalPath);
-                    changed = true;
+                    picChanged = true;
                 }
             }
 
             foreach (var seg in flatSegmentsToAdd) {
                 if (!picVm.Keywords.Contains(seg, StringComparer.OrdinalIgnoreCase)) {
                     picVm.AddKeyword(seg);
-                    changed = true;
+                    picChanged = true;
                 }
             }
 
-            if (changed) {
+            if (picChanged) {
+                anyChanged = true;
                 _curationQueue.Enqueue(picVm.Picture);
                 if (_centroidService != null && _embeddingService != null) {
                     _ = Task.Run(async () => {
@@ -644,7 +667,7 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
             }
         }
 
-        if (changed) {
+        if (anyChanged) {
             Log.Information("Manually added tag '{Keyword}' to {Count} picture(s): [{PictureNames}]",
                 input, targetVms.Count, string.Join(", ", targetVms.Select(p => p.Name)));
             UpdateActiveKeywords();
@@ -678,8 +701,12 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
             targetVms.Add(SelectedPicture);
         }
 
-        bool changed = false;
+        if (!targetVms.Any()) return;
+
+        bool anyChanged = false;
         foreach (var picVm in targetVms) {
+            bool picChanged = false;
+
             if (normalized.Contains('|')) {
                 // 1. Remove the matching hierarchical path(s)
                 var matchingPaths = picVm.Keywords
@@ -687,7 +714,7 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
                     .ToList();
                 foreach (var mp in matchingPaths) {
                     picVm.RemoveKeyword(mp);
-                    changed = true;
+                    picChanged = true;
                 }
 
                 // 2. Remove associated segments if they are not used in any remaining hierarchical path
@@ -706,7 +733,7 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
                         var flatMatch = picVm.Keywords.FirstOrDefault(k => k.Equals(seg, StringComparison.OrdinalIgnoreCase));
                         if (flatMatch != null) {
                             picVm.RemoveKeyword(flatMatch);
-                            changed = true;
+                            picChanged = true;
                         }
                     }
                 }
@@ -717,11 +744,12 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
                     k.Equals(keyword.Trim(), StringComparison.OrdinalIgnoreCase));
                 if (existing != null) {
                     picVm.RemoveKeyword(existing);
-                    changed = true;
+                    picChanged = true;
                 }
             }
 
-            if (changed) {
+            if (picChanged) {
+                anyChanged = true;
                 _curationQueue.Enqueue(picVm.Picture);
                 if (_centroidService != null && _embeddingService != null) {
                     _ = Task.Run(async () => {
@@ -732,7 +760,7 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
             }
         }
 
-        if (changed) {
+        if (anyChanged) {
             Log.Information("Manually removed tag '{Keyword}' from {Count} picture(s): [{PictureNames}]",
                 keyword, targetVms.Count, string.Join(", ", targetVms.Select(p => p.Name)));
             UpdateActiveKeywords();
@@ -760,27 +788,18 @@ public partial class DetailsInspectorViewModel : ViewModelBase, IRecipient<Pictu
             targetVms.Add(SelectedPicture);
         }
 
-        bool changed = false;
-        foreach (var picVm in targetVms) {
-            bool hasAny = paths.Any(p => picVm.Keywords.Contains(p, StringComparer.OrdinalIgnoreCase));
-            if (hasAny) {
-                foreach (var p in paths) {
-                    RemoveKeyword(p);
-                }
-            } else {
-                foreach (var p in paths) {
-                    AddKeyword(p);
-                }
-            }
-            changed = true;
-        }
+        if (!targetVms.Any()) return;
 
-        if (changed) {
-            Log.Information("Toggled quick tag '{TagName}' on {Count} picture(s): [{PictureNames}]",
-                tag.Name, targetVms.Count, string.Join(", ", targetVms.Select(p => p.Name)));
-            UpdateActiveKeywords();
-            UpdateQuickTagStates();
-            WeakReferenceMessenger.Default.Send(new PictureKeywordsChangedMessage(targetVms));
+        bool allHaveTag = targetVms.All(pic => paths.Any(p => pic.Keywords.Contains(p, StringComparer.OrdinalIgnoreCase)));
+
+        if (allHaveTag) {
+            foreach (var p in paths) {
+                RemoveKeyword(p);
+            }
+        } else {
+            foreach (var p in paths) {
+                AddKeyword(p);
+            }
         }
     }
 

--- a/Tests/DetailsInspectorViewModelTests.cs
+++ b/Tests/DetailsInspectorViewModelTests.cs
@@ -310,4 +310,92 @@ public class DetailsInspectorViewModelTests {
         Assert.That(_viewModel.ActiveKeywordGroups[0].Title, Is.EqualTo("Keywords"));
         Assert.That(_viewModel.ActiveKeywordGroups[0].Chips[0].LeafName, Is.EqualTo("Hero"));
     }
+
+    [Test]
+    public void AddKeyword_WhenMultiplePicturesSelected_AppliesTagToAllSelectedPictures() {
+        var pic1 = new Picture { Name = "pic1.jpg", Keywords = new List<string>() };
+        var pic2 = new Picture { Name = "pic2.jpg", Keywords = new List<string> { "Hero" } };
+        var vm1 = new PictureItemViewModel(pic1);
+        var vm2 = new PictureItemViewModel(pic2);
+
+        _viewModel.SelectedPictures.Add(vm1);
+        _viewModel.SelectedPictures.Add(vm2);
+        _viewModel.SelectedPicture = vm1;
+
+        _viewModel.AddKeyword("Car");
+
+        Assert.That(vm1.Keywords, Contains.Item("Vehicles|Car"));
+        Assert.That(vm1.Keywords, Contains.Item("Vehicles"));
+        Assert.That(vm1.Keywords, Contains.Item("Car"));
+
+        Assert.That(vm2.Keywords, Contains.Item("Vehicles|Car"));
+        Assert.That(vm2.Keywords, Contains.Item("Vehicles"));
+        Assert.That(vm2.Keywords, Contains.Item("Car"));
+        Assert.That(vm2.Keywords, Contains.Item("Hero"));
+
+        Assert.That(_curationQueue.EnqueuedPictures, Contains.Item(pic1));
+        Assert.That(_curationQueue.EnqueuedPictures, Contains.Item(pic2));
+    }
+
+    [Test]
+    public void RemoveKeywordChip_WhenMultiplePicturesSelected_RemovesTagFromAllSelectedPictures() {
+        var pic1 = new Picture { Name = "pic1.jpg", Keywords = new List<string> { "Vehicles|Car", "Vehicles", "Car", "Hero" } };
+        var pic2 = new Picture { Name = "pic2.jpg", Keywords = new List<string> { "Vehicles|Car", "Vehicles", "Car" } };
+        var vm1 = new PictureItemViewModel(pic1);
+        var vm2 = new PictureItemViewModel(pic2);
+
+        _viewModel.SelectedPictures.Add(vm1);
+        _viewModel.SelectedPictures.Add(vm2);
+        _viewModel.SelectedPicture = vm1;
+
+        var carChip = _viewModel.ActiveKeywordChips.First(c => c.RawValue == "Vehicles|Car");
+        _viewModel.RemoveKeywordChip(carChip);
+
+        Assert.That(vm1.Keywords, Does.Not.Contain("Vehicles|Car"));
+        Assert.That(vm1.Keywords, Does.Not.Contain("Vehicles"));
+        Assert.That(vm1.Keywords, Does.Not.Contain("Car"));
+        Assert.That(vm1.Keywords, Contains.Item("Hero"));
+
+        Assert.That(vm2.Keywords, Does.Not.Contain("Vehicles|Car"));
+        Assert.That(vm2.Keywords, Does.Not.Contain("Vehicles"));
+        Assert.That(vm2.Keywords, Does.Not.Contain("Car"));
+    }
+
+    [Test]
+    public void ToggleQuickTag_WhenMultiplePicturesSelected_AddsTagToAllIfAnyMissing_AndRemovesIfAllPresent() {
+        var carTag = _settingsService.Current.MasterTags.First(t => t.Name == "Car");
+        _settingsService.Current.TagGroups = new List<TagGroup> {
+            new() { GroupId = Guid.NewGuid(), GroupName = "Quick", TagIds = new ObservableCollection<Guid> { carTag.Id } }
+        };
+        _settingsService.Current.ActiveTagGroupId = _settingsService.Current.TagGroups[0].GroupId;
+
+        // Force rebuild quick tags
+        _viewModel.ActiveTagGroup = _settingsService.Current.TagGroups[0];
+
+        var pic1 = new Picture { Name = "pic1.jpg", Keywords = new List<string> { "Vehicles|Car", "Vehicles", "Car" } };
+        var pic2 = new Picture { Name = "pic2.jpg", Keywords = new List<string>() };
+        var vm1 = new PictureItemViewModel(pic1);
+        var vm2 = new PictureItemViewModel(pic2);
+
+        _viewModel.SelectedPictures.Add(vm1);
+        _viewModel.SelectedPictures.Add(vm2);
+        _viewModel.SelectedPicture = vm1;
+
+        var quickBtn = _viewModel.QuickTagButtons.First(b => b.Tag.Id == carTag.Id);
+
+        // State: pic1 has tag, pic2 does not (not all have it) -> toggling should add to all (pic2 gets it)
+        _viewModel.ToggleQuickTagCommand.Execute(quickBtn);
+
+        Assert.That(vm1.Keywords, Contains.Item("Vehicles|Car"));
+        Assert.That(vm2.Keywords, Contains.Item("Vehicles|Car"));
+        Assert.That(vm2.Keywords, Contains.Item("Vehicles"));
+        Assert.That(vm2.Keywords, Contains.Item("Car"));
+
+        // State: both have tag -> toggling should remove from all
+        _viewModel.ToggleQuickTagCommand.Execute(quickBtn);
+
+        Assert.That(vm1.Keywords, Does.Not.Contain("Vehicles|Car"));
+        Assert.That(vm2.Keywords, Does.Not.Contain("Vehicles|Car"));
+    }
 }
+


### PR DESCRIPTION
- Updated `DetailsInspectorViewModel` to support applying tags, labels, and ratings across multiple selected pictures.
- Added logic to handle hierarchical paths during tag addition/removal.
- Improved error handling and logging for bulk operations.
- Introduced new unit tests to validate bulk behavior for adding/removing keywords, toggling quick tags, and setting status/labels.
- Bumped version to 1.9.3.
