### PR TITLE
feat(tags): enhance tag filter toolbar with toggle and reset improvements

### DIFF
--- a/Picturebot/Picturebot.csproj
+++ b/Picturebot/Picturebot.csproj
@@ -8,7 +8,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <AssemblyName>Picturebot</AssemblyName>
         <RootNamespace>Picturebot</RootNamespace>
-        <Version>1.9.3</Version>
+        <Version>1.9.4</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Picturebot/ViewModels/FilterToolbarViewModel.cs
+++ b/Picturebot/ViewModels/FilterToolbarViewModel.cs
@@ -190,6 +190,8 @@ public partial class FilterToolbarViewModel : ViewModelBase
         OnPropertyChanged(nameof(IsTagFilterActive));
         OnPropertyChanged(nameof(ActiveTagFiltersCountText));
         OnPropertyChanged(nameof(IsAnyFilterActive));
+        OnPropertyChanged(nameof(AreAllTagsSelected));
+        OnPropertyChanged(nameof(SelectAllButtonText));
         _onFilterChanged?.Invoke();
     }
 
@@ -229,6 +231,10 @@ public partial class FilterToolbarViewModel : ViewModelBase
         _isUpdating = true;
         try
         {
+            IsMatchAny = true;
+            IsMatchAll = false;
+            IsMatchNot = false;
+
             IsFlaggedActive = false;
             IsNeutralActive = false;
             IsRejectedActive = false;
@@ -266,6 +272,12 @@ public partial class FilterToolbarViewModel : ViewModelBase
 
     public bool IsTagFilterActive =>
         RootNodes.Any(r => r.IsChecked != false) || AllTags.Any(t => t.IsSelected);
+
+    public bool AreAllTagsSelected =>
+        (RootNodes.Count > 0 && RootNodes.All(r => r.IsChecked == true)) ||
+        (RootNodes.Count == 0 && AllTags.Count > 0 && AllTags.All(t => t.IsSelected));
+
+    public string SelectAllButtonText => AreAllTagsSelected ? "Uncheck All Tags" : "Select All";
 
     public string ActiveTagFiltersCountText
     {
@@ -417,6 +429,8 @@ public partial class FilterToolbarViewModel : ViewModelBase
         RefreshVisibleTags();
         OnPropertyChanged(nameof(IsTagFilterActive));
         OnPropertyChanged(nameof(ActiveTagFiltersCountText));
+        OnPropertyChanged(nameof(AreAllTagsSelected));
+        OnPropertyChanged(nameof(SelectAllButtonText));
     }
 
     private TagFilterNodeViewModel BuildTreeNode(
@@ -493,6 +507,35 @@ public partial class FilterToolbarViewModel : ViewModelBase
     }
 
     [RelayCommand]
+    public void ToggleAllTags()
+    {
+        if (AreAllTagsSelected)
+        {
+            _isUpdating = true;
+            try
+            {
+                foreach (var root in RootNodes)
+                {
+                    root.SetCheckedRecursive(false);
+                }
+                foreach (var tag in AllTags)
+                {
+                    tag.IsSelected = false;
+                }
+            }
+            finally
+            {
+                _isUpdating = false;
+                UpdateCollectionsAndNotify();
+            }
+        }
+        else
+        {
+            SelectAllTags();
+        }
+    }
+
+    [RelayCommand]
     public void SelectAllTags()
     {
         _isUpdating = true;
@@ -520,6 +563,10 @@ public partial class FilterToolbarViewModel : ViewModelBase
         _isUpdating = true;
         try
         {
+            IsMatchAny = true;
+            IsMatchAll = false;
+            IsMatchNot = false;
+
             foreach (var root in RootNodes)
             {
                 root.SetCheckedRecursive(false);

--- a/Picturebot/Views/FilterToolbarView.axaml
+++ b/Picturebot/Views/FilterToolbarView.axaml
@@ -398,7 +398,7 @@
 
                             <!-- Actions inside flyout -->
                             <Grid ColumnDefinitions="*,8,*">
-                                <Button Grid.Column="0" Content="Select All" Command="{Binding SelectAllTagsCommand}" HorizontalAlignment="Stretch" Height="30" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Classes="secondary" FontSize="11"/>
+                                <Button Grid.Column="0" Content="{Binding SelectAllButtonText}" Command="{Binding ToggleAllTagsCommand}" HorizontalAlignment="Stretch" Height="30" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Classes="secondary" FontSize="11"/>
                                 <Button Grid.Column="2" Content="Clear Filter" Command="{Binding ClearTagFiltersCommand}" HorizontalAlignment="Stretch" Height="30" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Classes="secondary" FontSize="11"/>
                             </Grid>
                         </StackPanel>

--- a/Tests/FilterToolbarViewModelTests.cs
+++ b/Tests/FilterToolbarViewModelTests.cs
@@ -82,20 +82,49 @@ public class FilterToolbarViewModelTests {
     }
 
     [Test]
-    public void ClearTagFilters_ResetsTreeAndToolbar() {
+    public void ClearTagFilters_ResetsTreeAndToolbar_AndDefaultsMatchModeToAny() {
         var vm = new FilterToolbarViewModel();
         vm.UpdateAvailableTags(CreateSamplePictures());
 
         var facesNode = vm.RootNodes.First(n => n.Name == "faces");
         facesNode.IsChecked = true;
+        vm.IsMatchNot = true; // Switch to NOT (EXCLUDE)
 
         Assert.That(vm.IsTagFilterActive, Is.True);
+        Assert.That(vm.IsMatchNot, Is.True);
+        Assert.That(vm.IsMatchAny, Is.False);
 
         vm.ClearTagFiltersCommand.Execute(null);
 
         Assert.That(vm.IsTagFilterActive, Is.False);
         Assert.That(facesNode.IsChecked, Is.EqualTo(false));
         Assert.That(facesNode.Children.All(c => c.IsChecked == false), Is.True);
+        Assert.That(vm.IsMatchAny, Is.True, "ClearTagFilters must default back to 'Any' option.");
+        Assert.That(vm.IsMatchNot, Is.False);
+        Assert.That(vm.IsMatchAll, Is.False);
+    }
+
+    [Test]
+    public void ToggleAllTags_WhenAllChecked_SwitchesButtonTextToUncheckAllTags_AndUnchecksAll() {
+        var vm = new FilterToolbarViewModel();
+        vm.UpdateAvailableTags(CreateSamplePictures());
+
+        Assert.That(vm.AreAllTagsSelected, Is.False);
+        Assert.That(vm.SelectAllButtonText, Is.EqualTo("Select All"));
+
+        // Toggle when not all checked -> checks all
+        vm.ToggleAllTagsCommand.Execute(null);
+
+        Assert.That(vm.AreAllTagsSelected, Is.True);
+        Assert.That(vm.SelectAllButtonText, Is.EqualTo("Uncheck All Tags"));
+        Assert.That(vm.RootNodes.All(r => r.IsChecked == true), Is.True);
+
+        // Toggle when all are checked -> unchecks all
+        vm.ToggleAllTagsCommand.Execute(null);
+
+        Assert.That(vm.AreAllTagsSelected, Is.False);
+        Assert.That(vm.SelectAllButtonText, Is.EqualTo("Select All"));
+        Assert.That(vm.RootNodes.All(r => r.IsChecked == false), Is.True);
     }
 
     [Test]


### PR DESCRIPTION
- Added `ToggleAllTagsCommand` to enable toggling between selecting and unselecting all tags.
- Updated `ClearTagFiltersCommand` to reset match mode to the default "Any" option.
- Modified `FilterToolbarView.axaml` to bind the button text dynamically using `SelectAllButtonText`.
- Added unit tests to verify toggle and reset behavior.
- Bumped version to 1.9.4.
